### PR TITLE
Tweak to install matplotlib release candidate 3v11rc0

### DIFF
--- a/docs/src/user_manual/explanation/iris_xarray.rst
+++ b/docs/src/user_manual/explanation/iris_xarray.rst
@@ -140,7 +140,7 @@ There is also relevant documentation
 `at this page <https://docs.xarray.dev/en/stable/user-guide/weather-climate.html#weather-and-climate-data>`_.
 
 In some particular aspects, CF data is not loaded well (or at all), and in many cases
-output is not fully CF compliant (as-per `the cf checker <https://cfchecker.ncas.ac.uk/>`_).
+output is not fully CF compliant (as-per `the cf checker <https://github.com/cedadev/cf-checker/>`_).
 
 * xarray has it's own interpretation of coordinates, which is different from the CF-based
   approach in Iris, and means that the use of the "coordinates" attribute in output is

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -77,6 +77,9 @@ This document explains the changes made to Iris for this release
    appears once you click on a link away from the landing page.  Also moved
    the search box to the top navigation bar. (:pull:`7060`)
 
+#. `@trexfeathers`_ switched to using the offical URL of the `cf-checker`_, after
+   our previous URL of choice was taken down. (:pull:`7072`)
+
 
 💼 Internal
 ===========
@@ -104,3 +107,4 @@ This document explains the changes made to Iris for this release
 
 .. comment
     Whatsnew resources in alphabetical order:
+.. _cf-checker: https://github.com/cedadev/cf-checker


### PR DESCRIPTION
This is awkward because the RC is apparently not included on the anaconda conda-forge channel  "conda-forge/label//matplotlob_rc", even though previously versions have been
