### PR TITLE
Overinstall mpl release candidate3v11v0 release candidate

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -111,7 +111,7 @@ jobs:
       - name: "nox cache"
         uses: ./.github/workflows/composite/nox-cache
         with:
-          cache_build: 0
+          cache_build: 1
           env_name: ${{ env.ENV_NAME }}
           lock_file: ${{ env.LOCK_FILE }}
 

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -111,7 +111,7 @@ jobs:
       - name: "nox cache"
         uses: ./.github/workflows/composite/nox-cache
         with:
-          cache_build: 6
+          cache_build: 0
           env_name: ${{ env.ENV_NAME }}
           lock_file: ${{ env.LOCK_FILE }}
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -142,7 +142,7 @@ def prepare_venv(session: nox.sessions.Session) -> None:
         # populate the environment from the lockfile
         logger.debug(f"Populating conda env at {venv_dir}")
         session.conda_install("--file", str(lockfile))
-        session.conda_install(MPL_URL_3V11RC0)
+        session.install(MPL_URL_3V11RC0)
         cache_venv(session)
 
     elif venv_changed(session):
@@ -152,7 +152,7 @@ def prepare_venv(session: nox.sessions.Session) -> None:
         session.virtualenv.reuse_existing = False
         session.virtualenv.create()
         session.conda_install("--file", str(lockfile))
-        session.conda_install(MPL_URL_3V11RC0)
+        session.install(MPL_URL_3V11RC0)
         session.virtualenv.reuse_existing = _re_orig
         cache_venv(session)
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -142,7 +142,7 @@ def prepare_venv(session: nox.sessions.Session) -> None:
         # populate the environment from the lockfile
         logger.debug(f"Populating conda env at {venv_dir}")
         session.conda_install("--file", str(lockfile))
-        session.conda_install("--url", MPL_URL_3V11RC0)
+        session.conda_install(MPL_URL_3V11RC0)
         cache_venv(session)
 
     elif venv_changed(session):
@@ -152,7 +152,7 @@ def prepare_venv(session: nox.sessions.Session) -> None:
         session.virtualenv.reuse_existing = False
         session.virtualenv.create()
         session.conda_install("--file", str(lockfile))
-        session.conda_install("--url", MPL_URL_3V11RC0)
+        session.conda_install(MPL_URL_3V11RC0)
         session.virtualenv.reuse_existing = _re_orig
         cache_venv(session)
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -108,6 +108,13 @@ def cache_cartopy(session: nox.sessions.Session) -> None:
         )
 
 
+MPL_URL_3V11RC0 = (
+    "https://files.pythonhosted.org/packages/b2/d1/"
+    "6a9ba3c934b6d272c894db9ea80257527be9a962b18d4b98b2323104b86b/"
+    "matplotlib-3.11.0rc1.tar.gz"
+)
+
+
 def prepare_venv(session: nox.sessions.Session) -> None:
     """Create and cache the nox session conda environment.
 
@@ -135,6 +142,7 @@ def prepare_venv(session: nox.sessions.Session) -> None:
         # populate the environment from the lockfile
         logger.debug(f"Populating conda env at {venv_dir}")
         session.conda_install("--file", str(lockfile))
+        session.conda_install("--url", MPL_URL_3V11RC0)
         cache_venv(session)
 
     elif venv_changed(session):
@@ -144,6 +152,7 @@ def prepare_venv(session: nox.sessions.Session) -> None:
         session.virtualenv.reuse_existing = False
         session.virtualenv.create()
         session.conda_install("--file", str(lockfile))
+        session.conda_install("--url", MPL_URL_3V11RC0)
         session.virtualenv.reuse_existing = _re_orig
         cache_venv(session)
 


### PR DESCRIPTION
Try mpl 3v11 release candidate.
This is a bit awkward because the RC is apparently not included on the anaconda conda-forge channel "conda-forge/label/matplotlob_rc", even though previously versions have been.

So I hacked noxfile.py to over-install it from PyPI.
Checking the [feedstock changes](https://github.com/conda-forge/matplotlib-feedstock/compare/5fb967c...fb64667), it looks like no dependencies or versions have changed from the 3v10 ones,
which is lucky