### PR TITLE
DOCS: Voted tables styling adjusted

### DIFF
--- a/docs/src/voted_issues.rst
+++ b/docs/src/voted_issues.rst
@@ -24,8 +24,8 @@ the below table.
 
    <!-- Must import jquery before the datatables css and js files. -->
    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-   <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/2.3.2/css/dataTables.dataTables.min.css">
-   <script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/2.3.2/js/dataTables.min.js"></script>
+   <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/2.3.8/css/dataTables.dataTables.min.css">
+   <script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/2.3.8/js/dataTables.min.js"></script>
 
 
    <table id="voted_issues_table" class="hover row-border order-column" style="width:100%">
@@ -48,9 +48,11 @@ the below table.
            $('#voted_issues_table').DataTable( {
               <!-- "ajax": 'voted-issues.json', -->
               "ajax": 'https://raw.githubusercontent.com/scitools/voted_issues/main/voted-issues.json',
+              // docs: https://datatables.net/reference/option/
               "lengthMenu": [10, 25, 50, 100],
               "pageLength": 10,
               "order": [[ 0, "desc" ]],
+              "orderClasses": false,
               "bJQueryUI": true,
            } );
         } );

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -80,6 +80,10 @@ This document explains the changes made to Iris for this release
 #. `@trexfeathers`_ switched to using the offical URL of the `cf-checker`_, after
    our previous URL of choice was taken down. (:pull:`7072`)
 
+#. `@tkknight`_ updated the voted table that uses datatables to not highlight the
+   sorted column or row as is uses the incorrect theme color (light). Also updated
+   the datatables version from 2.3.2 to 2.3.8. (:pull:`????`)
+
 
 💼 Internal
 ===========

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -82,7 +82,7 @@ This document explains the changes made to Iris for this release
 
 #. `@tkknight`_ updated the voted table that uses datatables to not highlight the
    sorted column or row as is uses the incorrect theme color (light). Also updated
-   the datatables version from 2.3.2 to 2.3.8. (:pull:`????`)
+   the datatables version from 2.3.2 to 2.3.8. (:pull:`7079`)
 
 
 💼 Internal


### PR DESCRIPTION
## 🚀 Pull Request

### Description
* Updates datatables.net version
* Updates voted tables datatables options to not highlight the sorted column as it seems to use the light theme making it hard to read.

### Before Fix
<img width="750" height="182" alt="image" src="https://github.com/user-attachments/assets/185c84aa-ebf0-46a8-b781-f3278af3ba6b" />

### After this Fix
<img width="695" height="181" alt="image" src="https://github.com/user-attachments/assets/9dfd143c-0db7-4404-92ff-ac74fe072d47" />


---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

---
Add any of the below labels to trigger actions on this PR:

- https://github.com/SciTools/iris/labels/benchmark_this
