### PR TITLE
docs: fix duplicated words in iris_cubes, s3_io, and release docs

### DIFF
--- a/docs/src/developers_guide/release.rst
+++ b/docs/src/developers_guide/release.rst
@@ -179,7 +179,7 @@ conda-forge
 
 Iris is available on conda-forge as ``iris``.
 
-This is managed via the the Iris conda recipe on the
+This is managed via the Iris conda recipe on the
 `conda-forge iris-feedstock`_, which is updated after the release is cut on
 GitHub, followed by automatic build and publish of the
 conda package on the `conda-forge Anaconda channel`_.

--- a/docs/src/user_manual/explanation/iris_cubes.rst
+++ b/docs/src/user_manual/explanation/iris_cubes.rst
@@ -91,7 +91,7 @@ A cube consists of:
 
 * an attributes dictionary which, other than some protected CF names, can
   hold arbitrary extra metadata. This implements the concept of dataset-level
-  and variable-level attributes when loading and and saving NetCDF files (see
+  and variable-level attributes when loading and saving NetCDF files (see
   :class:`~iris.cube.CubeAttrsDict` and NetCDF
   :func:`~iris.fileformats.netcdf.saver.save` for more).
 * a list of cell methods to represent operations which have already been

--- a/docs/src/user_manual/tutorial/s3_io.rst
+++ b/docs/src/user_manual/tutorial/s3_io.rst
@@ -103,7 +103,7 @@ S3 bucket **onto** -- e.g.
 Setup AWS credentials
 ~~~~~~~~~~~~~~~~~~~~~
 Provide S3 access credentials in an AWS credentials file, as described
-`here in the the s3-fuse documentation <https://github.com/s3fs-fuse/s3fs-fuse/blob/master/README.md#examples>`_.
+`here in the s3-fuse documentation <https://github.com/s3fs-fuse/s3fs-fuse/blob/master/README.md#examples>`_.
 
 There is a general introduction to AWS credentials
 `here in the AWS documentation <https://docs.aws.amazon.com/cli/latest/userguide/getting-started-quickstart.html>`_


### PR DESCRIPTION
Three one-line typo fixes for duplicated words in docs:
- `docs/src/user_manual/explanation/iris_cubes.rst` — "...when loading and and saving NetCDF files..." → "...when loading and saving NetCDF files..."
- `docs/src/user_manual/tutorial/s3_io.rst` — "`here in the the s3-fuse documentation ..." → "`here in the s3-fuse documentation ..."
- `docs/src/developers_guide/release.rst` — "This is managed via the the Iris conda recipe on the" → "This is managed via the Iris conda recipe on the"

No content/structure change.