### PR TITLE
DOCS: Limit the llms.txt generation to be on readthedocs only (not local)

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -167,7 +167,6 @@ extensions = [
     "sphinx_copybutton",
     "sphinx_design",
     "sphinx_gallery.gen_gallery",
-    "sphinx_llm.txt",
     "sphinx_needs",
     "sphinx_reredirects",
     "user_manual_directives",
@@ -181,11 +180,16 @@ else:
 
 # -- sphinx-llm ---------------------------------------------------------------
 # See https://github.com/NVIDIA/sphinx-llm
-llms_txt_enabled = True
-llms_txt_build_parallel = True
-llms_txt_suffix_mode = "auto"
-llms_txt_full_build = True
-llms_txt_description = "A powerful, format-agnostic, community-driven Python package for analysing and visualising Earth science data"
+
+if on_rtd:
+    autolog("[READTHEDOCS] [sphinx_llm.txt] Loading extension and configuring.")
+    extensions.append("sphinx_llm.txt")
+
+    llms_txt_enabled = True
+    llms_txt_build_parallel = True
+    llms_txt_suffix_mode = "auto"
+    llms_txt_full_build = True
+    llms_txt_description = "A powerful, format-agnostic, community-driven Python package for analysing and visualising Earth science data"
 
 # -- Napoleon extension -------------------------------------------------------
 # See https://sphinxcontrib-napoleon.readthedocs.io/en/latest/sphinxcontrib.napoleon.html


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Only includes the extension to create the llms.txt/llms-full.txt when being built on the readthedocs.

Related to https://github.com/SciTools/iris/pull/7105

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

---
Add any of the below labels to trigger actions on this PR:

- https://github.com/SciTools/iris/labels/benchmark_this
