### PR TITLE
Allow printing of a length-0 coordinate (#6531)

### DIFF
--- a/changelog/7122.bugfix.rst
+++ b/changelog/7122.bugfix.rst
@@ -1,0 +1,3 @@
+:user:`gaoflow` fixed coordinate summaries so that length-0 string and
+date-like coordinates print as empty arrays instead of raising
+``ValueError``. (:issue:`6531`)

--- a/lib/iris/coords.py
+++ b/lib/iris/coords.py
@@ -406,8 +406,9 @@ class _DimensionalMetadata(CFVariableMixin, metaclass=ABCMeta):
 
             if data.dtype.kind == "U":
                 # Strings : N.B. includes all missing data
-                # find the longest.
-                length = max(len(str(x)) for x in data.flatten())
+                # find the longest (an empty array, e.g. a length-0 time
+                # coordinate, has no elements, so fall back to 0). See #6531.
+                length = max((len(str(x)) for x in data.flatten()), default=0)
                 # Pre-apply a common formatting width.
                 formatter = {"all": lambda x: str(x).ljust(length)}
 

--- a/lib/iris/tests/unit/coords/test_Coord.py
+++ b/lib/iris/tests/unit/coords/test_Coord.py
@@ -1482,6 +1482,37 @@ class Test___str__:
         result = coord.__str__()
         assert expected == result
 
+    def test_empty_time_coord(self):
+        # A length-0 time coordinate (an as-yet-unfilled unlimited dimension)
+        # should print rather than raising (#6531).
+        coord = DimCoord([], standard_name="time", units="days since 1970-01-01")
+        expected = "\n".join(
+            [
+                "DimCoord :  time / (days since 1970-01-01, standard calendar)",
+                "    points: []",
+                "    shape: (0,)",
+                "    dtype: float64",
+                "    standard_name: 'time'",
+            ]
+        )
+        result = coord.__str__()
+        assert expected == result
+
+    def test_empty_string_coord(self):
+        # A length-0 string coordinate also exercises the empty-array path.
+        coord = AuxCoord(np.array([], dtype="<U1"), long_name="label")
+        expected = "\n".join(
+            [
+                "AuxCoord :  label / (unknown)",
+                "    points: []",
+                "    shape: (0,)",
+                "    dtype: <U1",
+                "    long_name: 'label'",
+            ]
+        )
+        result = coord.__str__()
+        assert expected == result
+
     def test_non_time_unit(self):
         coord = DimCoord([1.0])
         expected = "\n".join(


### PR DESCRIPTION
## 🚀 Pull Request

### Description

Closes #6531.

Printing a length-0 coordinate raised a `ValueError` instead of producing a summary:

```python
>>> from iris.coords import DimCoord
>>> t_coord = DimCoord([], standard_name="time", units="days since 1999-01-01")
>>> print(t_coord)
ValueError: max() iterable argument is empty
```

As confirmed by @SciTools/peloton on the issue, a length-0 time coordinate is a **valid** object — it represents an unlimited dimension that does not yet have any points — so printing it should not crash.

### Cause

`Coord.summary()` formats string- and date-like values by first finding the longest element so it can apply a common width:

```python
length = max(len(str(x)) for x in data.flatten())
```

For an empty array this generator is empty, so `max()` raises. (Date-like coordinates reach this branch because `num2date` converts the points to strings first; the original report's `vectorize`/`otypes` error no longer occurs with current `cf-units`, leaving this `max()` call as the remaining failure.)

### Fix

Pass `default=0` to `max()`, so an empty array yields a zero width and formats as `[]`. Non-empty coordinates are unaffected.

```python
>>> print(t_coord)
DimCoord :  time / (days since 1999-01-01, standard calendar)
    points: []
    shape: (0,)
    dtype: float64
    standard_name: 'time'
```

### Verification

- New tests `Test___str__::test_empty_time_coord` and `::test_empty_string_coord` (both date-like and plain-string empty paths). They fail on `main` and pass here.
- Full `tests/unit/coords/` and `tests/unit/representation/` suites pass (470 tests).
- `ruff check` / `ruff format` clean.