### PR TITLE
Fix Cube.rolling_window with lazy auxiliary coordinates (#6480)

### DIFF
--- a/changelog/7123.bugfix.rst
+++ b/changelog/7123.bugfix.rst
@@ -1,0 +1,3 @@
+:user:`gaoflow` fixed :meth:`iris.cube.Cube.rolling_window` so that it no
+longer raises a ``TypeError`` when the cube has a lazy auxiliary coordinate
+along the windowed dimension. (:issue:`6480`)

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -5243,9 +5243,7 @@ x            -               -
                 # window and the bounds are the first and last points in the
                 # window as with numeric coordinates.
                 new_points = np.apply_along_axis(lambda x: "|".join(x), -1, new_bounds)
-                # Index with a list rather than a tuple: a tuple is interpreted
-                # as a multidimensional index by Dask, so lazy coordinates would
-                # otherwise fail here (see #6480).
+                # Use list indexing so Dask selects columns, not dimensions.
                 new_bounds = new_bounds[:, [0, -1]]
             else:
                 # Take the first and last element of the rolled window (i.e.

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -5243,7 +5243,6 @@ x            -               -
                 # window and the bounds are the first and last points in the
                 # window as with numeric coordinates.
                 new_points = np.apply_along_axis(lambda x: "|".join(x), -1, new_bounds)
-                # Use list indexing so Dask selects columns, not dimensions.
                 new_bounds = new_bounds[:, [0, -1]]
             else:
                 # Take the first and last element of the rolled window (i.e.

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -5243,12 +5243,15 @@ x            -               -
                 # window and the bounds are the first and last points in the
                 # window as with numeric coordinates.
                 new_points = np.apply_along_axis(lambda x: "|".join(x), -1, new_bounds)
-                new_bounds = new_bounds[:, (0, -1)]
+                # Index with a list rather than a tuple: a tuple is interpreted
+                # as a multidimensional index by Dask, so lazy coordinates would
+                # otherwise fail here (see #6480).
+                new_bounds = new_bounds[:, [0, -1]]
             else:
                 # Take the first and last element of the rolled window (i.e.
                 # the bounds) and the new points are the midpoints of these
                 # bounds.
-                new_bounds = new_bounds[:, (0, -1)]
+                new_bounds = new_bounds[:, [0, -1]]
                 new_points = np.mean(new_bounds, axis=-1)
 
             # wipe the coords points and set the bounds

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -1087,17 +1087,16 @@ class Test_rolling_window:
         _shared_utils.assert_masked_array_equal(expected_result, res_cube.data)
 
     def test_lazy_aux_coord(self):
-        # A lazy aux-coord paralleling the rolled dimension must not cause a
-        # failure, and should give the same result as a real one, staying lazy
         # (see #6480).
+        window = 2
         self.cube.add_aux_coord(AuxCoord(da.arange(6), long_name="lazy_extra"), 0)
-        res_cube = self.cube.rolling_window("val", iris.analysis.MEAN, 3)
+        res_cube = self.cube.rolling_window("val", iris.analysis.MEAN, window, mdtol=0)
         result_coord = res_cube.coord("lazy_extra")
         assert result_coord.has_lazy_points()
         assert result_coord.has_lazy_bounds()
         expected = AuxCoord(
-            np.array([1.0, 2.0, 3.0, 4.0]),
-            bounds=np.array([[0, 2], [1, 3], [2, 4], [3, 5]]),
+            np.array([0.5, 1.5, 2.5, 3.5, 4.5]),
+            bounds=np.array([[0, 1], [1, 2], [2, 3], [3, 4], [4, 5]]),
             long_name="lazy_extra",
         )
         assert result_coord == expected

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -1086,6 +1086,22 @@ class Test_rolling_window:
         )
         _shared_utils.assert_masked_array_equal(expected_result, res_cube.data)
 
+    def test_lazy_aux_coord(self):
+        # A lazy aux-coord paralleling the rolled dimension must not cause a
+        # failure, and should give the same result as a real one, staying lazy
+        # (see #6480).
+        self.cube.add_aux_coord(AuxCoord(da.arange(6), long_name="lazy_extra"), 0)
+        res_cube = self.cube.rolling_window("val", iris.analysis.MEAN, 3)
+        result_coord = res_cube.coord("lazy_extra")
+        assert result_coord.has_lazy_points()
+        assert result_coord.has_lazy_bounds()
+        expected = AuxCoord(
+            np.array([1.0, 2.0, 3.0, 4.0]),
+            bounds=np.array([[0, 2], [1, 3], [2, 4], [3, 5]]),
+            long_name="lazy_extra",
+        )
+        assert result_coord == expected
+
     def test_ancillary_variables_and_cell_measures_kept(self, dataless):
         if dataless:
             self.cube.data = None

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -1087,7 +1087,6 @@ class Test_rolling_window:
         _shared_utils.assert_masked_array_equal(expected_result, res_cube.data)
 
     def test_lazy_aux_coord(self):
-        # (see #6480).
         window = 2
         self.cube.add_aux_coord(AuxCoord(da.arange(6), long_name="lazy_extra"), 0)
         res_cube = self.cube.rolling_window("val", iris.analysis.MEAN, window, mdtol=0)


### PR DESCRIPTION
## 🚀 Pull Request

### Description

Closes #6480 (and the duplicate #6639).

:meth:`iris.cube.Cube.rolling_window` raised a `TypeError` when the cube had a **lazy** auxiliary coordinate running along the windowed dimension:

```python
import numpy as np, dask.array as da
from iris.coords import DimCoord, AuxCoord
from iris.cube import Cube
from iris.analysis import MEAN

dimco = DimCoord(np.arange(12), standard_name="time", units="s")
auxco = AuxCoord(da.arange(12), long_name="x")   # lazy
cube = Cube(np.arange(12),
            dim_coords_and_dims=[(dimco, 0)],
            aux_coords_and_dims=[(auxco, 0)])
cube.rolling_window(coord="time", window=3, aggregator=MEAN)
```

```
TypeError: '>=' not supported between instances of 'tuple' and 'int'
```

### Cause

When building the new coordinate bounds, `rolling_window` selects the first and last point of each window with:

```python
new_bounds = new_bounds[:, (0, -1)]
```

A **tuple** index is interpreted by Dask as a *multidimensional* index (and so it tries to use `0` and `-1` as indices into successive axes), which fails for a lazy array. NumPy happens to tolerate the tuple here, so the bug only surfaces for lazy coordinates.

### Fix

Index with the **list** `[0, -1]` instead. NumPy and Dask both treat a list as selecting the first and last column, so the result is identical for real arrays and now also works (and stays lazy) for lazy ones. This is the fix hinted at by @pp-mo on the issue. Both the numeric and string-coordinate branches are updated.

### Verification

- New test `Test_rolling_window::test_lazy_aux_coord` — asserts a lazy aux-coord no longer fails, stays lazy (points **and** bounds), and equals the real-array result. It fails on `main` and passes here.
- Manually confirmed identical results for lazy vs. real, numeric vs. string coordinates.
- Full `Test_rolling_window` and `tests/unit/util/test_rolling_window.py` suites pass (25 tests).
- `ruff check` / `ruff format` clean.