### PR TITLE
Copy target coordinates onto regridded result cube (#6844)

### DIFF
--- a/changelog/7124.bugfix.rst
+++ b/changelog/7124.bugfix.rst
@@ -1,0 +1,4 @@
+:user:`gaoflow` fixed regridding so that horizontal coordinates of the result
+cube are copies of, rather than references to, the target grid's coordinates.
+Previously, modifying a result coordinate also modified the target cube's
+coordinate, and vice versa. (:issue:`6844`)

--- a/lib/iris/analysis/_regrid.py
+++ b/lib/iris/analysis/_regrid.py
@@ -1040,6 +1040,10 @@ def _create_cube(data, src, src_dims, tgt_coords, num_tgt_dims, regrid_callback)
     if num_tgt_dims == 1:
         grid_dim_x = grid_dim_y = min(src_dims)
     for tgt_coord, dim in zip(tgt_coords, (grid_dim_x, grid_dim_y)):
+        # Copy so that the result does not share coordinate objects with the
+        # target grid (mutating one would otherwise mutate the other). See
+        # #6844.
+        tgt_coord = tgt_coord.copy()
         if len(tgt_coord.shape) == 1:
             if isinstance(tgt_coord, DimCoord) and dim is not None:
                 result.add_dim_coord(tgt_coord, dim)

--- a/lib/iris/tests/unit/analysis/area_weighted/test_AreaWeightedRegridder.py
+++ b/lib/iris/tests/unit/analysis/area_weighted/test_AreaWeightedRegridder.py
@@ -122,6 +122,22 @@ class Test:
         result = regridder(src)
         _shared_utils.assert_array_all_close(result.data, target.data)
 
+    def test_result_coords_independent_of_target(self):
+        # The horizontal coordinates of the result must be copies, not the
+        # same objects as the target's: mutating one must not mutate the
+        # other (#6844).
+        src, target = self.grids()
+        regridder = AreaWeightedRegridder(src, target)
+        result = regridder(src)
+        for name in ("latitude", "longitude"):
+            result_coord = result.coord(name)
+            target_coord = target.coord(name)
+            assert result_coord == target_coord
+            assert result_coord is not target_coord
+            original = target_coord.points.copy()
+            result_coord.points = result_coord.points + 100
+            _shared_utils.assert_array_equal(target.coord(name).points, original)
+
     def test_multiple_src_on_same_grid(self):
         coord_names = ["latitude", "longitude"]
         src1 = self.cube(np.linspace(20, 32, 4), np.linspace(10, 22, 4))


### PR DESCRIPTION
## 🚀 Pull Request

### Description

Closes #6844.

After regridding, the horizontal (X/Y) coordinates on the **result** cube were the *same objects* as the coordinates on the **target grid** cube, so mutating one mutated the other:

```python
result = src_cube.regrid(grid_cube, AreaWeighted())
result.coord("longitude") is grid_cube.coord("longitude")   # True!
result.coord("longitude").points += 100
grid_cube.coord("longitude").points                         # also changed!
```

### Cause

`iris.analysis._regrid._create_cube` builds the result cube and attaches the target's coordinates. Its docstring already states:

> Horizontal coordinates are copied from the target cube.

…and the *source* coordinates it carries across are indeed copied (`coord.copy()`). But the target coordinates were added by reference:

```python
for tgt_coord, dim in zip(tgt_coords, (grid_dim_x, grid_dim_y)):
    ...
    result.add_dim_coord(tgt_coord, dim)   # same object as the target's
```

This affects all regridders that share `_create_cube`. (The curvilinear caller happened to pre-copy its coords, but `AreaWeighted` and the rectilinear `RectilinearRegridder` did not — and a regridder also reuses a single target snapshot across calls, so the aliasing could leak between successive results too.)

### Fix

Copy each target coordinate inside `_create_cube` before adding it, matching both the docstring and the existing treatment of source coordinates. This centralises the behaviour for every regridder. The pre-existing `.copy()` in the curvilinear caller becomes harmlessly redundant.

### Verification

- New test `Test::test_result_coords_independent_of_target` — asserts the result's lat/lon equal the target's but are distinct objects, and that mutating the result leaves the target unchanged. It fails on `main` and passes here.
- Manually confirmed for `AreaWeighted`, `Linear` and `Nearest`: result coordinates carry the correct points/bounds yet are independent of the target.
- `tests/unit/analysis/regrid/` and `tests/unit/analysis/area_weighted/` suites pass (81 tests; the 4 `Test__derived_coord` errors are pre-existing and unrelated — they require optional regridding dependencies not installed locally).
- `ruff check` / `ruff format` clean.