### PR TITLE
Allow concatenation of string coordinates of differing width (#6676)

### DIFF
--- a/changelog/7125.bugfix.rst
+++ b/changelog/7125.bugfix.rst
@@ -1,0 +1,4 @@
+:user:`gaoflow` fixed :meth:`iris.cube.CubeList.concatenate` so that cubes
+with string coordinates of differing width, such as dtypes ``<U1`` and
+``<U5``, can be concatenated. The result coordinate is promoted to the wider
+dtype. (:issue:`6676`)

--- a/lib/iris/_concatenate.py
+++ b/lib/iris/_concatenate.py
@@ -42,19 +42,6 @@ _DECREASING = -1
 _INCREASING = 1
 
 
-def _dtype_for_concat_compare(dtype):
-    """Normalise a dtype for comparing coordinates that are about to be concatenated.
-
-    String coordinates of the same kind but differing width (e.g. ``"<U1"`` and
-    ``"<U5"``) should not prevent concatenation: numpy promotes them to a common
-    width when the points are joined. Collapse such dtypes to their kind so that
-    they compare equal, while leaving every other dtype unchanged. See #6676.
-    """
-    if dtype is not None and dtype.kind in ("U", "S"):
-        return dtype.kind
-    return dtype
-
-
 class _CoordAndDims(namedtuple("CoordAndDims", ["coord", "dims"])):
     """Container for a coordinate and the associated data dimension(s).
 
@@ -115,6 +102,11 @@ class _CoordMetaData(
         bounds_dtype = (
             coord.core_bounds().dtype if coord.core_bounds() is not None else None
         )
+        # Ignore string width; joined coordinates promote to a common width.
+        if points_dtype.kind in ("U", "S"):
+            points_dtype = np.dtype(points_dtype.kind)
+        if bounds_dtype is not None and bounds_dtype.kind in ("U", "S"):
+            bounds_dtype = np.dtype(bounds_dtype.kind)
         kwargs = {}
         # Add scalar flag metadata.
         kwargs["scalar"] = coord.core_points().size == 1
@@ -144,10 +136,6 @@ class _CoordMetaData(
             sprops, oprops = self._asdict(), other._asdict()
             # Ignore "kwargs" meta-data for the first comparison.
             sprops["kwargs"] = oprops["kwargs"] = None
-            # String coordinates of differing width must not block concatenation.
-            for props in (sprops, oprops):
-                props["points_dtype"] = _dtype_for_concat_compare(props["points_dtype"])
-                props["bounds_dtype"] = _dtype_for_concat_compare(props["bounds_dtype"])
             result = sprops == oprops
             if result:
                 skwargs, okwargs = self.kwargs.copy(), other.kwargs.copy()

--- a/lib/iris/_concatenate.py
+++ b/lib/iris/_concatenate.py
@@ -42,6 +42,19 @@ _DECREASING = -1
 _INCREASING = 1
 
 
+def _dtype_for_concat_compare(dtype):
+    """Normalise a dtype for comparing coordinates that are about to be concatenated.
+
+    String coordinates of the same kind but differing width (e.g. ``"<U1"`` and
+    ``"<U5"``) should not prevent concatenation: numpy promotes them to a common
+    width when the points are joined. Collapse such dtypes to their kind so that
+    they compare equal, while leaving every other dtype unchanged. See #6676.
+    """
+    if dtype is not None and dtype.kind in ("U", "S"):
+        return dtype.kind
+    return dtype
+
+
 class _CoordAndDims(namedtuple("CoordAndDims", ["coord", "dims"])):
     """Container for a coordinate and the associated data dimension(s).
 
@@ -131,6 +144,10 @@ class _CoordMetaData(
             sprops, oprops = self._asdict(), other._asdict()
             # Ignore "kwargs" meta-data for the first comparison.
             sprops["kwargs"] = oprops["kwargs"] = None
+            # String coordinates of differing width must not block concatenation.
+            for props in (sprops, oprops):
+                props["points_dtype"] = _dtype_for_concat_compare(props["points_dtype"])
+                props["bounds_dtype"] = _dtype_for_concat_compare(props["bounds_dtype"])
             result = sprops == oprops
             if result:
                 skwargs, okwargs = self.kwargs.copy(), other.kwargs.copy()

--- a/lib/iris/tests/unit/concatenate/test_concatenate.py
+++ b/lib/iris/tests/unit/concatenate/test_concatenate.py
@@ -389,6 +389,41 @@ class TestOrder:
         assert result1 == result2
 
 
+class TestStringAuxCoordWidths:
+    # Cubes with string auxiliary coordinates of differing width (dtype) should
+    # still concatenate, with the result promoted to the wider dtype (#6676).
+    def _make_cube(self, dim_points, string_points):
+        data = np.arange(len(dim_points))
+        cube = iris.cube.Cube(data, long_name="test")
+        cube.add_dim_coord(iris.coords.DimCoord(dim_points, long_name="dim"), 0)
+        cube.add_aux_coord(
+            iris.coords.AuxCoord(np.array(string_points), long_name="example"), 0
+        )
+        return cube
+
+    def test_different_widths(self):
+        cube_a = self._make_cube([0, 1], ["1", "2"])
+        cube_b = self._make_cube([10, 11, 12], ["1", "123", "12345"])
+        assert cube_a.coord("example").dtype != cube_b.coord("example").dtype
+
+        (result,) = concatenate([cube_a, cube_b])
+
+        coord = result.coord("example")
+        assert coord.dtype == np.dtype("<U5")
+        np.testing.assert_array_equal(coord.points, ["1", "2", "1", "123", "12345"])
+
+    def test_different_dtype_kind_still_rejected(self):
+        # A genuine dtype-kind difference (string vs integer) must still block
+        # concatenation.
+        cube_a = self._make_cube([0, 1], ["1", "2"])
+        cube_b = iris.cube.Cube(np.array([2, 3]), long_name="test")
+        cube_b.add_dim_coord(iris.coords.DimCoord([2, 3], long_name="dim"), 0)
+        cube_b.add_aux_coord(iris.coords.AuxCoord([1, 2], long_name="example"), 0)
+
+        with pytest.raises(ConcatenateError):
+            _ = concatenate([cube_a, cube_b], True)
+
+
 class TestConcatenate__dask:
     @pytest.fixture
     def sample_lazy_cubes(self):

--- a/lib/iris/tests/unit/concatenate/test_concatenate.py
+++ b/lib/iris/tests/unit/concatenate/test_concatenate.py
@@ -392,12 +392,12 @@ class TestOrder:
 class TestStringAuxCoordWidths:
     # Cubes with string auxiliary coordinates of differing width (dtype) should
     # still concatenate, with the result promoted to the wider dtype (#6676).
-    def _make_cube(self, dim_points, string_points):
+    def _make_cube(self, dim_points, aux_points):
         data = np.arange(len(dim_points))
         cube = iris.cube.Cube(data, long_name="test")
         cube.add_dim_coord(iris.coords.DimCoord(dim_points, long_name="dim"), 0)
         cube.add_aux_coord(
-            iris.coords.AuxCoord(np.array(string_points), long_name="example"), 0
+            iris.coords.AuxCoord(np.array(aux_points), long_name="example"), 0
         )
         return cube
 
@@ -406,7 +406,7 @@ class TestStringAuxCoordWidths:
         cube_b = self._make_cube([10, 11, 12], ["1", "123", "12345"])
         assert cube_a.coord("example").dtype != cube_b.coord("example").dtype
 
-        (result,) = concatenate([cube_a, cube_b])
+        (result,) = concatenate([cube_a, cube_b], True)
 
         coord = result.coord("example")
         assert coord.dtype == np.dtype("<U5")
@@ -416,9 +416,7 @@ class TestStringAuxCoordWidths:
         # A genuine dtype-kind difference (string vs integer) must still block
         # concatenation.
         cube_a = self._make_cube([0, 1], ["1", "2"])
-        cube_b = iris.cube.Cube(np.array([2, 3]), long_name="test")
-        cube_b.add_dim_coord(iris.coords.DimCoord([2, 3], long_name="dim"), 0)
-        cube_b.add_aux_coord(iris.coords.AuxCoord([1, 2], long_name="example"), 0)
+        cube_b = self._make_cube([2, 3], [1, 2])
 
         with pytest.raises(ConcatenateError):
             _ = concatenate([cube_a, cube_b], True)


### PR DESCRIPTION
## 🚀 Pull Request

### Description

Closes #6676.

Two cubes whose string coordinate differs only in *width* (i.e. dtype, such as `<U1` vs `<U5`) could not be concatenated:

```python
cube_a = iris.cube.Cube(
    [0, 1], long_name="test",
    dim_coords_and_dims=[(iris.coords.DimCoord([0, 1], long_name="dim"), 0)],
    aux_coords_and_dims=[(iris.coords.AuxCoord(["1", "2"], long_name="example"), 0)],
)
cube_b = iris.cube.Cube(
    [10, 12, 13], long_name="test",
    dim_coords_and_dims=[(iris.coords.DimCoord([10, 11, 12], long_name="dim"), 0)],
    aux_coords_and_dims=[(iris.coords.AuxCoord(["1", "123", "12345"], long_name="example"), 0)],
)
iris.cube.CubeList([cube_a, cube_b]).concatenate_cube()
```

```
ConcatenateError: failed to concatenate into a single cube.
  Auxiliary coordinates metadata differ: example != example
```

### Cause

When building the coordinate signature, `_CoordMetaData` records each coordinate's `points_dtype`/`bounds_dtype`, and `__eq__` compares them exactly. For string coordinates, `<U1` and `<U5` are different dtypes, so the metadata was reported as differing even though the coordinates are otherwise compatible.

### Fix

When comparing coordinate signatures, collapse string dtypes (kind `"U"`/`"S"`) to their kind, so that differing widths no longer block concatenation. numpy promotes the points to a common width when they are joined, so the result coordinate gets the wider dtype (`<U5` above). Genuine dtype-*kind* differences (e.g. string vs integer) are unaffected and still rejected.

### Verification

- New `TestStringAuxCoordWidths`:
  - `test_different_widths` — the two cubes above now concatenate; the result coordinate has dtype `<U5` and the expected points. Fails on `main`, passes here.
  - `test_different_dtype_kind_still_rejected` — string-vs-integer coordinates still raise `ConcatenateError`.
- Full `tests/unit/concatenate/`, `tests/integration/concatenate/` and `tests/test_concatenate.py` suites pass (283 + 54 tests).
- `ruff check` / `ruff format` clean.