### PR TITLE
Keep lazy_elementwise blocks as arrays for scalar-returning ops (#6965)

### DIFF
--- a/changelog/7126.bugfix.rst
+++ b/changelog/7126.bugfix.rst
@@ -1,0 +1,4 @@
+:user:`gaoflow` fixed an error when computing (e.g. saving) a scalar lazy
+cube whose units had been converted with :meth:`~iris.cube.Cube.convert_units`.
+The unit conversion could yield a plain Python scalar for the 0-dimensional
+block, which Dask was then unable to store. (:issue:`6965`)

--- a/lib/iris/_lazy_data.py
+++ b/lib/iris/_lazy_data.py
@@ -592,7 +592,13 @@ def lazy_elementwise(lazy_array, elementwise_op):
     dtype = elementwise_op(np.zeros(1, lazy_array.dtype)).dtype
     meta = da.utils.meta_from_array(lazy_array).astype(dtype)
 
-    return da.map_blocks(elementwise_op, lazy_array, dtype=dtype, meta=meta)
+    def wrapped_op(block):
+        # Some operations return a Python scalar for a 0-dimensional block
+        # (e.g. cf_units.Unit.convert on a scalar array), which Dask cannot
+        # store. Ensure each block remains an array. See #6965.
+        return np.asanyarray(elementwise_op(block))
+
+    return da.map_blocks(wrapped_op, lazy_array, dtype=dtype, meta=meta)
 
 
 def map_complete_blocks(src, func, dims, out_sizes, dtype, *args, **kwargs):

--- a/lib/iris/_lazy_data.py
+++ b/lib/iris/_lazy_data.py
@@ -8,7 +8,7 @@ To avoid replicating implementation-dependent test and conversion code.
 
 """
 
-from functools import lru_cache, wraps
+from functools import lru_cache, partial, wraps
 from types import ModuleType
 from typing import Sequence
 
@@ -560,6 +560,13 @@ def co_realise_cubes(*cubes):
         cube.data = result
 
 
+def _as_array_wrapper(op, block):
+    # Some operations return a Python scalar for a 0-dimensional block
+    # (e.g. cf_units.Unit.convert on a scalar array), which Dask cannot
+    # store. Ensure each block remains an array. See #6965.
+    return np.asanyarray(op(block))
+
+
 def lazy_elementwise(lazy_array, elementwise_op):
     """Apply a (numpy-style) elementwise array operation to a lazy array.
 
@@ -592,13 +599,12 @@ def lazy_elementwise(lazy_array, elementwise_op):
     dtype = elementwise_op(np.zeros(1, lazy_array.dtype)).dtype
     meta = da.utils.meta_from_array(lazy_array).astype(dtype)
 
-    def wrapped_op(block):
-        # Some operations return a Python scalar for a 0-dimensional block
-        # (e.g. cf_units.Unit.convert on a scalar array), which Dask cannot
-        # store. Ensure each block remains an array. See #6965.
-        return np.asanyarray(elementwise_op(block))
-
-    return da.map_blocks(wrapped_op, lazy_array, dtype=dtype, meta=meta)
+    return da.map_blocks(
+        partial(_as_array_wrapper, elementwise_op),
+        lazy_array,
+        dtype=dtype,
+        meta=meta,
+    )
 
 
 def map_complete_blocks(src, func, dims, out_sizes, dtype, *args, **kwargs):

--- a/lib/iris/tests/unit/lazy_data/test_lazy_elementwise.py
+++ b/lib/iris/tests/unit/lazy_data/test_lazy_elementwise.py
@@ -38,3 +38,20 @@ class Test_lazy_elementwise:
         assert is_lazy_data(wrapped)
         assert wrapped.dtype == np.int_
         assert wrapped.compute().dtype == wrapped.dtype
+
+    def test_scalar_returning_op_on_0d(self):
+        # An op that returns a Python scalar for a 0-d block (e.g.
+        # cf_units.Unit.convert on a scalar array) must still yield an array,
+        # so that the result can be stored by Dask (#6965).
+        def scalar_op(array):
+            # Mimics returning a Python float for a scalar input.
+            return float(array) if array.ndim == 0 else array + 1.0
+
+        lazy_array = as_lazy_data(np.array(3.0))
+        assert lazy_array.ndim == 0
+        wrapped = lazy_elementwise(lazy_array, scalar_op)
+        assert is_lazy_data(wrapped)
+        result = wrapped.compute()
+        assert isinstance(result, np.ndarray)
+        assert result.shape == ()
+        assert result[()] == 3.0


### PR DESCRIPTION
## 🚀 Pull Request

### Description

Closes #6965.

Computing (e.g. saving) a **scalar lazy cube** whose units had been converted failed:

```python
import iris.analysis, dask, numpy as np, dask.array as da
from iris.coords import DimCoord
from iris.cube import Cube

cube = Cube(da.arange(10), units="m",
            dim_coords_and_dims=[(DimCoord(np.arange(10), var_name="x"), 0)])
cube = cube.collapsed("x", iris.analysis.MIN)   # -> 0-dimensional, lazy
cube.convert_units("km")

delayed = iris.save(cube, "test.nc", compute=False)
dask.compute(delayed)
```

```
AttributeError: 'float' object has no attribute 'size'
```

The error only appears with `convert_units` and only when the result is stored lazily (calling `cube.data` directly is fine).

### Cause

`convert_units` applies the conversion lazily via `iris._lazy_data.lazy_elementwise`, which maps the operation over the blocks of the lazy array. The operation is `cf_units.Unit.convert`, and for a **0-dimensional** block that call returns a Python `float` rather than a 0-d array. Dask's store step then does `block.size`, which a `float` does not have.

### Fix

Wrap each block result in `np.asanyarray` inside `lazy_elementwise`, so a block always remains an array regardless of what the operation returns. For a normal (n-d) block this is a no-op; for the scalar case it restores the expected 0-d array. Masks are preserved (`asanyarray`).

### Verification

- New test `Test_lazy_elementwise::test_scalar_returning_op_on_0d` — an op that returns a Python scalar for a 0-d block now yields a 0-d `ndarray`. Fails on `main`, passes here.
- Reproducer above now saves successfully and round-trips the correct value (`0.0 km`); a 1-d `convert_units` remains lazy with correct values.
- Full `tests/unit/lazy_data/` suite (51) and the `convert_units` cube tests pass.
- `ruff check` / `ruff format` clean.