### PR TITLE
Fix geotiff export geotransform values for numpy >= 2.4

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -36,7 +36,10 @@ This document explains the changes made to Iris for this release
 🐛 Bugs Fixed
 =============
 
-#. N/A
+#. `@PraneelBhatia`_ fixed :func:`iris.experimental.raster.export_geotiff`,
+   which failed with a ``TypeError`` under numpy >= 2.4: the geotransform
+   values are now passed to GDAL as Python scalars instead of 1-element
+   arrays. (:issue:`7133`, :pull:`7140`)
 
 
 💣 Incompatible Changes
@@ -142,6 +145,7 @@ This document explains the changes made to Iris for this release
     core dev names are automatically included by the common_links.inc:
 
 .. _@hdyson: https://github.com/hdyson
+.. _@PraneelBhatia: https://github.com/PraneelBhatia
 
 
 .. comment

--- a/lib/iris/experimental/raster.py
+++ b/lib/iris/experimental/raster.py
@@ -173,7 +173,10 @@ def export_geotiff(cube, fname):
             )
         if not coord.is_contiguous():
             raise ValueError("Coordinate {!r} bounds must be contiguous.".format(name))
-        xy_step.append(np.diff(coord.bounds[0]))
+        # Take a Python scalar step value : GDAL's SetGeoTransform requires
+        # plain numbers, and numpy >= 2.4 no longer implicitly converts the
+        # 1-element array which np.diff produces here.
+        xy_step.append(np.diff(coord.bounds[0]).item())
         if not np.allclose(np.diff(coord.bounds), xy_step[-1]):
             msg = "Coordinate {!r} bounds must be regularly spaced.".format(name)
             raise ValueError(msg)
@@ -205,6 +208,6 @@ def export_geotiff(cube, fname):
             x_bounds = x_bounds.copy()
             x_bounds[big_indices] -= 360
 
-    x_min = np.min(x_bounds)
-    y_max = np.max(coord_y.bounds)
+    x_min = np.min(x_bounds).item()
+    y_max = np.max(coord_y.bounds).item()
     _gdal_write_array(x_min, x_step, y_max, y_step, coord_system, data, fname, "GTiff")

--- a/lib/iris/tests/unit/experimental/raster/test_export_geotiff.py
+++ b/lib/iris/tests/unit/experimental/raster/test_export_geotiff.py
@@ -162,7 +162,7 @@ class TestProjection:
 
 @_shared_utils.skip_gdal
 class TestGeoTransform:
-    def test_(self, tmp_path):
+    def _cube(self):
         data = np.arange(12).reshape(3, 4).astype(np.uint8)
         cube = Cube(data, "air_pressure_anomaly")
         coord = DimCoord([30, 40, 50], "latitude", units="degrees")
@@ -171,7 +171,22 @@ class TestGeoTransform:
         coord = DimCoord([-10, -5, 0, 5], "longitude", units="degrees")
         coord.guess_bounds()
         cube.add_dim_coord(coord, 1)
+        return cube
+
+    def test_(self, tmp_path):
+        cube = self._cube()
         temp_filename = str(tmp_path / "tmp.tif")
         export_geotiff(cube, temp_filename)
         dataset = gdal.Open(temp_filename, gdal.GA_ReadOnly)
         assert dataset.GetGeoTransform() == (-12.5, 5, 0, 55, 0, -10)
+
+    def test_scalar_transform_values(self, mocker, tmp_path):
+        # The geotransform values passed to GDAL must be Python scalars :
+        # numpy >= 2.4 no longer implicitly converts the 1-element arrays
+        # which were previously passed. See issue #7133.
+        write_array = mocker.patch("iris.experimental.raster._gdal_write_array")
+        export_geotiff(self._cube(), str(tmp_path / "tmp.tif"))
+        x_min, x_step, y_max, y_step = write_array.call_args.args[:4]
+        assert (x_min, x_step, y_max, y_step) == (-12.5, 5.0, 55.0, -10.0)
+        for value in (x_min, x_step, y_max, y_step):
+            assert isinstance(value, float)

--- a/lib/iris/tests/unit/experimental/raster/test_export_geotiff.py
+++ b/lib/iris/tests/unit/experimental/raster/test_export_geotiff.py
@@ -173,7 +173,7 @@ class TestGeoTransform:
         cube.add_dim_coord(coord, 1)
         return cube
 
-    def test_(self, tmp_path):
+    def test_geotransform(self, tmp_path):
         cube = self._cube()
         temp_filename = str(tmp_path / "tmp.tif")
         export_geotiff(cube, temp_filename)
@@ -189,4 +189,5 @@ class TestGeoTransform:
         x_min, x_step, y_max, y_step = write_array.call_args.args[:4]
         assert (x_min, x_step, y_max, y_step) == (-12.5, 5.0, 55.0, -10.0)
         for value in (x_min, x_step, y_max, y_step):
-            assert isinstance(value, float)
+            assert isinstance(value, (int, float))
+            assert not isinstance(value, np.generic)


### PR DESCRIPTION
## 🚀 Pull Request

### Description

Closes #7133

`iris.experimental.raster.export_geotiff` fails with `TypeError: not a number` from GDAL's `SetGeoTransform` under numpy >= 2.4: the x/y step values were the 1-element arrays produced by `np.diff(coord.bounds[0])`, and numpy >= 2.4 removed the implicit 1-element-array-to-scalar conversion which previously made this work.

This PR coerces all four geotransform inputs (`x_min`, `x_step`, `y_max`, `y_step`) to plain Python floats via `.item()`, as suggested in the issue — `.item()` is safe on scalars and size-1 arrays, and would raise on anything longer.

Also:

* Added a regression test (`test_scalar_transform_values`) which asserts the values passed to `_gdal_write_array` are Python floats, so the regression is guarded even on numpy < 2.4 installs (the geotiff tests need GDAL, which is not in the CI environment).
* Added a whatsnew entry.

Tested locally with python 3.13 / numpy 2.4.6 / GDAL 3.13.0: the issue's reproduction snippet now succeeds (`GetGeoTransform() == (-0.5, 1.0, 0.0, 4.5, 0.0, -1.0)`), and `pytest lib/iris/tests/unit/experimental/raster/test_export_geotiff.py` goes from 17 failed / 1 passed on `main` to 19 passed. The new test fails without the fix.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

---
Add any of the below labels to trigger actions on this PR:

- https://github.com/SciTools/iris/labels/benchmark_this