### PR TITLE
docs: add custom `readingtime` directive

### DIFF
--- a/docs/src/_static/readingtime.css
+++ b/docs/src/_static/readingtime.css
@@ -1,0 +1,12 @@
+.reading-time {
+    padding: 0.6em 1em;
+    background: var(--article-info-bg);
+    color: var(--article-info-fg);
+    border-left: 4px solid #1B8FB7;
+    border-radius: 4px;
+    margin-bottom: 1.2em;
+    font-style: normal;
+    font-weight: bold;
+}
+
+.fa-clock { color: #CADC6D !important; }

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -82,7 +82,7 @@ if on_rtd:
 # documentation root, use pathlib.Path().absolute() to make it absolute, like shown here.
 
 # custom sphinx extensions
-sys.path.append(str((Path("sphinxext").absolute())))
+sys.path.append(str(Path("sphinxext").absolute()))
 
 # add some sample files from the developers guide..
 sys.path.append(str(Path("developers_guide").absolute()))
@@ -154,6 +154,7 @@ rst_epilog = f"""
 extensions = [
     "matplotlib.sphinxext.mathmpl",
     "matplotlib.sphinxext.plot_directive",
+    "readingtime",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.coverage",
@@ -447,6 +448,9 @@ html_context = {
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
 html_style = "theme_override.css"
+html_css_files = [
+    "readingtime.css",
+]
 
 # list of sources to exclude from the build.
 exclude_patterns = []

--- a/docs/src/developers_guide/contributing_benchmarks.rst
+++ b/docs/src/developers_guide/contributing_benchmarks.rst
@@ -4,6 +4,9 @@
 
 Benchmarking
 ============
+
+.. readingtime::
+
 Iris includes architecture for benchmarking performance and other metrics of
 interest. This is done using the `Airspeed Velocity`_ (ASV) package.
 

--- a/docs/src/developers_guide/contributing_ci_tests.rst
+++ b/docs/src/developers_guide/contributing_ci_tests.rst
@@ -5,6 +5,8 @@
 Continuous Integration (CI) Testing
 ===================================
 
+.. readingtime::
+
 .. note:: Iris is currently supported and tested against |python_support|
           running on Linux.  We do not currently actively test on other
           platforms such as Windows or macOS.

--- a/docs/src/developers_guide/contributing_code_formatting.rst
+++ b/docs/src/developers_guide/contributing_code_formatting.rst
@@ -5,6 +5,8 @@
 Code Formatting
 ===============
 
+.. readingtime::
+
 To ensure a consistent code format throughout Iris, we recommend using
 tools to check the source directly.
 

--- a/docs/src/developers_guide/contributing_deprecations.rst
+++ b/docs/src/developers_guide/contributing_deprecations.rst
@@ -3,6 +3,8 @@
 Deprecations
 ************
 
+.. readingtime::
+
 If you need to make a backwards-incompatible change to a public API
 [#public-api]_ that has been included in a release (e.g. deleting a
 method), then you must first deprecate the old behaviour in at least

--- a/docs/src/developers_guide/contributing_documentation_easy.rst
+++ b/docs/src/developers_guide/contributing_documentation_easy.rst
@@ -6,6 +6,8 @@
 Contributing to the Documentation (the easy way)
 ------------------------------------------------
 
+.. readingtime::
+
 Documentation is important and we encourage any improvements that can be made.
 If you believe the documentation is not clear please contribute a change to
 improve the documentation for all users.

--- a/docs/src/developers_guide/contributing_documentation_full.rst
+++ b/docs/src/developers_guide/contributing_documentation_full.rst
@@ -5,6 +5,8 @@
 Contributing to the Documentation
 ---------------------------------
 
+.. readingtime::
+
 This guide is for those comfortable with the development process, looking for
 the specifics of how to apply that knowledge to Iris. You may instead find it
 easier to use the :ref:`contributing.documentation_easy`.
@@ -169,3 +171,58 @@ The reStructuredText (rst) output of the gallery is located in
 For more information on the directory structure and options please see the
 `sphinx-gallery getting started
 <https://sphinx-gallery.github.io/stable/getting_started.html>`_ documentation.
+
+
+.. _contributing.documentation.directives:
+
+Sphinx Directives
+~~~~~~~~~~~~~~~~~
+
+The following custom ``sphinx`` `reStructuredText`_ (``rst``) directives
+are available to documentation authors.
+
+``readingtime``
+""""""""""""""""
+
+**Usage:**
+
+.. code:: console
+
+   .. readingtime:: [<duration>|<wpm>]
+
+Calculates an *estimated* reading time of an entire page based on the
+number of words and a default *words-per-minute* reading heuristic for
+technical documents.
+
+Accepts an optional ``<duration>`` reading time (in minutes), a literal
+reading time to be quoted rather than calculated.
+
+The directive then creates a branded ``readingtime`` banner in-situ e.g.,
+
+.. code:: console
+
+   .. readingtime:: 5
+
+Generates the banner:
+
+.. readingtime:: 5
+
+Alternatively, provide an optional *words-per-minute* to override
+the directive default when calculating the reading time estimation e.g.,
+
+.. code:: console
+
+   ... readingtime:: 1000wpm
+
+Generates the following banner, using ``1,000`` words-per-minute to calculate
+the estimate to read this :ref:`contributing.documentation_full` page:
+
+.. readingtime:: 1000wpm
+
+.. note::
+
+   A default *words-per-minute* value will always be used to generate a reading
+   time for a directive with no arguments i.e., ``.. readingtime::``
+
+
+.. _reStructuredText: https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html

--- a/docs/src/developers_guide/contributing_graphics_tests.rst
+++ b/docs/src/developers_guide/contributing_graphics_tests.rst
@@ -5,6 +5,8 @@
 Adding or Updating Graphics Tests
 =================================
 
+.. readingtime::
+
 .. note::
 
   If a large number of images tests are failing due to an update to the

--- a/docs/src/developers_guide/contributing_pull_request_checklist.rst
+++ b/docs/src/developers_guide/contributing_pull_request_checklist.rst
@@ -5,6 +5,8 @@
 Pull Request Checklist
 ======================
 
+.. readingtime::
+
 All pull request will be reviewed by a core developer who will manage the
 process of merging. It is the responsibility of the contributor submitting a
 pull request to do their best to deliver a pull request which meets the

--- a/docs/src/developers_guide/contributing_pytest_conversions.rst
+++ b/docs/src/developers_guide/contributing_pytest_conversions.rst
@@ -6,6 +6,8 @@
 Converting From ``unittest`` to ``pytest``
 *******************************************
 
+.. readingtime::
+
 Conversion Checklist
 --------------------
 .. note::

--- a/docs/src/developers_guide/contributing_running_tests.rst
+++ b/docs/src/developers_guide/contributing_running_tests.rst
@@ -5,6 +5,8 @@
 Running the Tests
 *****************
 
+.. readingtime::
+
 There are two options for running the tests:
 
 * Use an environment you created yourself.  This requires more manual steps to

--- a/docs/src/developers_guide/contributing_tests.rst
+++ b/docs/src/developers_guide/contributing_tests.rst
@@ -6,6 +6,8 @@
 Writing Tests
 *************
 
+.. readingtime::
+
 .. note::
     If you're converting UnitTest tests to PyTest, check out
     :ref:`contributing_pytest_conversions`.

--- a/docs/src/developers_guide/documenting/docstrings.rst
+++ b/docs/src/developers_guide/documenting/docstrings.rst
@@ -4,6 +4,8 @@
 Docstrings
 ==========
 
+.. readingtime::
+
 Every public object in the Iris package should have an appropriate docstring.
 This is important as the docstrings are used by developers to understand
 the code and may be read directly in the source or via the

--- a/docs/src/developers_guide/documenting/rest_guide.rst
+++ b/docs/src/developers_guide/documenting/rest_guide.rst
@@ -6,6 +6,8 @@
 reST Quick Start
 ================
 
+.. readingtime::
+
 `reST`_ is used to create the documentation for Iris_.  It is used to author
 all of the documentation content including use in docstrings where appropriate.
 For more information see :ref:`docstrings`.

--- a/docs/src/developers_guide/documenting/whats_new_contributions.rst
+++ b/docs/src/developers_guide/documenting/whats_new_contributions.rst
@@ -6,6 +6,8 @@
 Contributing a "What's New" Entry
 =================================
 
+.. readingtime::
+
 Iris uses a file named ``latest.rst`` to keep a draft of upcoming development
 changes that will form the next stable release.  Contributions to the
 :ref:`iris_whatsnew` document are written by the developer most familiar

--- a/docs/src/developers_guide/github_app.rst
+++ b/docs/src/developers_guide/github_app.rst
@@ -3,6 +3,8 @@
 Token GitHub App
 ----------------
 
+.. readingtime::
+
 .. note::
 
    This section of the documentation is applicable only to GitHub `SciTools`_

--- a/docs/src/developers_guide/gitwash/configure_git.rst
+++ b/docs/src/developers_guide/gitwash/configure_git.rst
@@ -6,6 +6,8 @@
 Configure Git
 =============
 
+.. readingtime::
+
 .. _git-config-basic:
 
 Overview

--- a/docs/src/developers_guide/gitwash/development_workflow.rst
+++ b/docs/src/developers_guide/gitwash/development_workflow.rst
@@ -4,6 +4,8 @@
 Development Workflow
 ####################
 
+.. readingtime::
+
 You already have your own forked copy of the `iris`_ repository, by
 following :ref:`forking`. You have :ref:`set-up-fork`. You have configured
 git by following :ref:`configure-git`.  Now you are ready for some real work.

--- a/docs/src/developers_guide/gitwash/forking.rst
+++ b/docs/src/developers_guide/gitwash/forking.rst
@@ -6,6 +6,8 @@
 Making Your own Copy (fork) of Iris
 ===================================
 
+.. readingtime::
+
 You need to do this only once.  The instructions here are very similar
 to the instructions at https://help.github.com/forking/, please see
 that page for more detail.  We're repeating some of it here just to give the

--- a/docs/src/developers_guide/gitwash/set_up_fork.rst
+++ b/docs/src/developers_guide/gitwash/set_up_fork.rst
@@ -6,6 +6,8 @@
 Set up Your Fork
 ================
 
+.. readingtime::
+
 First you follow the instructions for :ref:`forking`.
 
 Overview

--- a/docs/src/developers_guide/release.rst
+++ b/docs/src/developers_guide/release.rst
@@ -5,6 +5,8 @@
 Releases
 ========
 
+.. readingtime::
+
 A release of Iris is a `tag on the SciTools/Iris`_ Github repository.
 
 Below is :ref:`iris_development_releases_steps`, followed by some prose on the

--- a/docs/src/sphinxext/readingtime.py
+++ b/docs/src/sphinxext/readingtime.py
@@ -1,3 +1,7 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the BSD license.
+# See LICENSE in the root of the repository for full licensing details.
 """Sphinx extension to estimate reading time for documentation pages."""
 
 from __future__ import annotations

--- a/docs/src/sphinxext/readingtime.py
+++ b/docs/src/sphinxext/readingtime.py
@@ -1,0 +1,129 @@
+"""Sphinx extension to estimate reading time for documentation pages."""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+import re
+from typing import TYPE_CHECKING
+
+from docutils import nodes  # type: ignore[import-untyped]
+from sphinx.util.docutils import SphinxDirective
+
+if TYPE_CHECKING:
+    from sphinx.application import Sphinx
+
+PATTERN = re.compile(r"^(\d+)wpm", re.IGNORECASE)
+"""Words-per-minute pattern matcher."""
+
+WPM = 125  # typically 100-150wpm
+"""Default words-per-minute reading speed for technical documentation."""
+
+
+def count_words(text: str) -> int:
+    """Count the number of words in a given text.
+
+    Parameters
+    ----------
+    text : str
+        The text to count words in.
+
+    Returns
+    -------
+    int
+        The number of words in the text.
+
+    """
+    words = re.findall(r"\w+", text)
+    return len(words)
+
+
+class ReadingTimeDirective(SphinxDirective):
+    """Directive to estimate reading time for a documentation page."""
+
+    has_content = False
+    optional_arguments = 1
+    final_argument_whitespace = False
+
+    def run(self) -> list[nodes.Node]:
+        """Estimate the reading time for a documentation page.
+
+        Directive accepts a single optional argument which may be either the
+        proposed reading-time i.e., do not calculate an estimate instead use
+        the value provided e.g. "10". Alternatively, the number of words per
+        minute (override ``WPM`` default) to be used for the estimation
+        e.g., "100wpm".
+
+        Returns
+        -------
+        list[nodes.Node]
+            A list containing a single raw HTML node with the estimated reading time.
+
+        """
+        env = self.env
+        docname = env.docname
+        source_path = env.doc2path(docname)
+
+        minutes = wpm = None
+
+        def convert(value: str) -> int:
+            """Convert argument from string to integer."""
+            try:
+                result = int(value)
+            except ValueError:
+                result = 0
+            return result
+
+        if self.arguments:
+            argument = self.arguments[0]
+
+            match = PATTERN.match(argument)
+
+            if match:
+                wpm = convert(match.group(1))
+            else:
+                minutes = convert(argument)
+
+        # optional wpm argument overrides the default for estimation
+        wpm = wpm or WPM
+
+        if minutes is None:
+            with Path(source_path).open("r", encoding="utf-8") as fi:
+                text = fi.read()
+
+            # common reading speed baselines for technical docs is 100-150 wpm
+            # let's roll with the lower end to be conservative and account for
+            # code snippets, figures, etc.
+            words = count_words(text)
+            minutes = max(1, math.ceil(words / wpm))
+
+        html = (
+            f'<div class="reading-time">'
+            f'<i class="fa-solid fa-clock"></i> '
+            f"Estimated reading time: {minutes} minute{'s' if minutes != 1 else ''}"
+            f"</div>"
+        )
+
+        return [nodes.raw("", html, format="html")]
+
+
+def setup(app: Sphinx) -> dict:
+    """Set up the reading time Sphinx extension.
+
+    Parameters
+    ----------
+    app : Sphinx
+        The Sphinx application object.
+
+    Returns
+    -------
+    dict
+        A dictionary containing the extension version.
+
+    """
+    app.add_directive("readingtime", ReadingTimeDirective)
+    return {
+        "version": "0.1.0",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/src/user_manual/explanation/dataless_cubes.rst
+++ b/docs/src/user_manual/explanation/dataless_cubes.rst
@@ -8,6 +8,9 @@
 ==============
 Dataless Cubes
 ==============
+
+.. readingtime::
+
 It is possible for a cube to exist without a data payload.
 In this case ``cube.data`` is ``None``, instead of containing an array (real or lazy) as
 usual.

--- a/docs/src/user_manual/explanation/iris_cubes.rst
+++ b/docs/src/user_manual/explanation/iris_cubes.rst
@@ -9,6 +9,8 @@
 Iris Data Structures
 ====================
 
+.. readingtime::
+
 The top level object in Iris is called a cube. A cube contains data and
 metadata about a phenomenon.
 

--- a/docs/src/user_manual/explanation/iris_philosophy.rst
+++ b/docs/src/user_manual/explanation/iris_philosophy.rst
@@ -9,6 +9,8 @@
 Iris' Philosophy
 ****************
 
+.. readingtime::
+
 .. _code-maintenance:
 
 Code Maintenance

--- a/docs/src/user_manual/explanation/iris_xarray.rst
+++ b/docs/src/user_manual/explanation/iris_xarray.rst
@@ -9,6 +9,8 @@
 Iris ❤️ :term:`Xarray`
 ======================
 
+.. readingtime::
+
 There is a lot of overlap between Iris and :term:`Xarray`, but some important
 differences too. Below is a summary of the most important differences, so that
 you can be prepared, and to help you choose the best package for your use case.

--- a/docs/src/user_manual/explanation/lenient_maths.rst
+++ b/docs/src/user_manual/explanation/lenient_maths.rst
@@ -8,6 +8,8 @@
 Lenient Cube Maths
 ******************
 
+.. readingtime::
+
 This section provides an overview of lenient cube maths. In particular, it explains
 what lenient maths involves, clarifies how it differs from normal or strict cube
 maths, and demonstrates how you can exercise fine control over whether your cube

--- a/docs/src/user_manual/explanation/lenient_metadata.rst
+++ b/docs/src/user_manual/explanation/lenient_metadata.rst
@@ -8,6 +8,8 @@
 Lenient Metadata
 ****************
 
+.. readingtime::
+
 This section discusses lenient metadata; what it is, what it means, and how you
 can perform **lenient** rather than **strict** operations with your metadata.
 

--- a/docs/src/user_manual/explanation/mesh_data_model.rst
+++ b/docs/src/user_manual/explanation/mesh_data_model.rst
@@ -10,6 +10,8 @@
 The Mesh Data Model
 *******************
 
+.. readingtime::
+
 .. important::
 
         This page is intended to summarise the essentials that Iris users need

--- a/docs/src/user_manual/explanation/mesh_partners.rst
+++ b/docs/src/user_manual/explanation/mesh_partners.rst
@@ -9,6 +9,9 @@
 
 Iris' Mesh Partner Packages
 ****************************
+
+.. readingtime::
+
 Python is an easy to use language and has formed a very strong collaborative
 scientific community, which is why Iris is written in Python. *Performant*
 Python relies on calls down to low level languages like C, which is ideal for

--- a/docs/src/user_manual/explanation/metadata.rst
+++ b/docs/src/user_manual/explanation/metadata.rst
@@ -8,6 +8,8 @@
 Metadata
 ********
 
+.. readingtime::
+
 This section provides a detailed overview of how your metadata is managed
 within Iris. In particular, it discusses what metadata is, where it fits
 into Iris, and more importantly how you can create, access, manipulate,

--- a/docs/src/user_manual/explanation/missing_data_handling.rst
+++ b/docs/src/user_manual/explanation/missing_data_handling.rst
@@ -7,6 +7,8 @@
 Missing Data Handling in Iris
 =============================
 
+.. readingtime::
+
 This document provides a brief overview of how Iris handles missing data values
 when datasets are loaded as cubes, and when cubes are saved or modified.
 

--- a/docs/src/user_manual/explanation/netcdf_io.rst
+++ b/docs/src/user_manual/explanation/netcdf_io.rst
@@ -33,6 +33,8 @@
 NetCDF I/O Handling in Iris
 =============================
 
+.. readingtime::
+
 This document provides a basic account of how Iris loads and saves NetCDF files.
 
 .. admonition:: Under Construction

--- a/docs/src/user_manual/explanation/real_and_lazy_data.rst
+++ b/docs/src/user_manual/explanation/real_and_lazy_data.rst
@@ -18,6 +18,8 @@
 Real and Lazy Data
 ==================
 
+.. readingtime::
+
 We have seen in the :doc:`../explanation/iris_cubes` section of the user guide that
 Iris cubes contain data and metadata about a phenomenon. The data element of a cube
 is always an array, but the array may be either "real" or "lazy".

--- a/docs/src/user_manual/explanation/temporal_coordinates.rst
+++ b/docs/src/user_manual/explanation/temporal_coordinates.rst
@@ -10,6 +10,8 @@
 Temporal Coordinates
 ====================
 
+.. readingtime::
+
 Here we provide some handy patterns and tips for working with temporal
 coordinates i.e., ``time`` coordinates. 
 

--- a/docs/src/user_manual/explanation/um_files_loading.rst
+++ b/docs/src/user_manual/explanation/um_files_loading.rst
@@ -23,6 +23,8 @@
 Iris Handling of PP and Fieldsfiles
 ===================================
 
+.. readingtime::
+
 This document provides a basic account of how PP and Fieldsfiles data is
 represented within Iris.
 It describes how Iris represents data from the Met Office Unified Model (UM),

--- a/docs/src/user_manual/explanation/ux_guide.rst
+++ b/docs/src/user_manual/explanation/ux_guide.rst
@@ -8,6 +8,8 @@
 Reviewing the Iris User Experience
 **********************************
 
+.. readingtime::
+
 .. todo:: https://github.com/SciTools/iris/issues/6867; this page belongs in 'Get Involved'
 
 Often, improving and updating the existing user experience can fall behind fixing create new features,

--- a/docs/src/user_manual/explanation/which_regridder_to_use.rst
+++ b/docs/src/user_manual/explanation/which_regridder_to_use.rst
@@ -11,6 +11,8 @@
 Which Regridder to Use
 ======================
 
+.. readingtime::
+
 This section compares all the regridding schemes which exist in `Iris`_, and
 externally in `iris-esmf-regrid`_ with a view to helping you to choose the right
 regridder for your workflow. The choice of regridder

--- a/docs/src/user_manual/explanation/why_iris.rst
+++ b/docs/src/user_manual/explanation/why_iris.rst
@@ -8,6 +8,8 @@
 Why Iris
 ========
 
+.. readingtime::
+
 **A powerful, format-agnostic, community-driven Python package for analysing
 and visualising Earth science data.**
 

--- a/docs/src/user_manual/how_to/filtering_warnings.rst
+++ b/docs/src/user_manual/how_to/filtering_warnings.rst
@@ -9,6 +9,8 @@
 Filtering Warnings
 ==================
 
+.. readingtime::
+
 Since Iris cannot predict your specific needs, it by default raises Warnings
 for anything that might be a problem for **any** user, and is designed to work with
 you to ``ignore`` Warnings which you do not find helpful.

--- a/docs/src/user_manual/how_to/installing.rst
+++ b/docs/src/user_manual/how_to/installing.rst
@@ -8,6 +8,8 @@
 Installing
 ==========
 
+.. readingtime::
+
 Iris can be installed using conda or pip.
 
 .. note:: Iris is currently supported and tested against |python_support|

--- a/docs/src/user_manual/how_to/mesh_conversions.rst
+++ b/docs/src/user_manual/how_to/mesh_conversions.rst
@@ -8,6 +8,8 @@
 Converting Other Mesh Formats
 *****************************
 
+.. readingtime::
+
 Iris' Mesh Data Model is based primarily on the CF-UGRID conventions  (see
 :doc:`../../user_manual/explanation/mesh_data_model`), but other mesh formats can be converted to fit into this
 model, **enabling use of Iris' specialised mesh support**. Below are some

--- a/docs/src/user_manual/how_to/mesh_operations.rst
+++ b/docs/src/user_manual/how_to/mesh_operations.rst
@@ -8,6 +8,8 @@
 Working with Mesh Data
 **********************
 
+.. readingtime::
+
 .. note:: Several of the operations below rely on the optional dependencies
           mentioned in :doc:`../../user_manual/explanation/mesh_partners`.
 

--- a/docs/src/user_manual/how_to/navigating_a_cube.rst
+++ b/docs/src/user_manual/how_to/navigating_a_cube.rst
@@ -7,6 +7,8 @@
 Navigating a Cube
 =================
 
+.. readingtime::
+
 .. testsetup::
 
         import iris

--- a/docs/src/user_manual/how_to/plugins.rst
+++ b/docs/src/user_manual/how_to/plugins.rst
@@ -10,6 +10,8 @@
 Plugins
 =======
 
+.. readingtime::
+
 Iris supports **plugins** under the ``iris.plugins`` `namespace package`_.
 This allows packages that extend Iris' functionality to be developed and
 maintained independently, while still being installed into ``iris.plugins``

--- a/docs/src/user_manual/reference/citation.rst
+++ b/docs/src/user_manual/reference/citation.rst
@@ -9,6 +9,8 @@
 Citing Iris
 ===========
 
+.. readingtime::
+
 If Iris played an important part in your research then please add us to your
 reference list by using the recommendations below.
 

--- a/docs/src/user_manual/reference/phrasebook.rst
+++ b/docs/src/user_manual/reference/phrasebook.rst
@@ -10,6 +10,8 @@
 Package Phrasebook
 ===================
 
+.. readingtime::
+
 There are a number of similar packages to Iris, and a lot of these have their own
 terminology for similar things. Whether you're coming or going, we hope this might
 be a helpful guide to these differences!

--- a/docs/src/user_manual/section_indexes/dask_best_practices.rst
+++ b/docs/src/user_manual/section_indexes/dask_best_practices.rst
@@ -3,6 +3,8 @@
 Dask Best Practices
 *******************
 
+.. readingtime::
+
 This section outlines some of the best practices when using Dask with Iris. These
 practices involve improving performance through rechunking, making the best use of
 computing clusters and avoiding parallelisation conflicts between Dask and NumPy.

--- a/docs/src/user_manual/tutorial/controlling_merge.rst
+++ b/docs/src/user_manual/tutorial/controlling_merge.rst
@@ -9,6 +9,8 @@
 Controlling Merge and Concatenate
 =================================
 
+.. readingtime::
+
 Preliminaries
 -------------
 

--- a/docs/src/user_manual/tutorial/cube_maths.rst
+++ b/docs/src/user_manual/tutorial/cube_maths.rst
@@ -9,6 +9,7 @@
 Cube Maths
 ==========
 
+.. readingtime::
 
 The section :doc:`../how_to/navigating_a_cube` highlighted that
 every cube has a data attribute;

--- a/docs/src/user_manual/tutorial/cube_statistics.rst
+++ b/docs/src/user_manual/tutorial/cube_statistics.rst
@@ -9,6 +9,8 @@
 Cube Statistics
 ===============
 
+.. readingtime::
+
 .. seealso::
 
     Relevant gallery example:

--- a/docs/src/user_manual/tutorial/dask_bags_and_greed.rst
+++ b/docs/src/user_manual/tutorial/dask_bags_and_greed.rst
@@ -8,6 +8,8 @@
 3. Dask Bags and Greedy Parallelism
 -----------------------------------
 
+.. readingtime::
+
 Here is a journey that demonstrates:
 
 * How to apply dask.bags to an existing script

--- a/docs/src/user_manual/tutorial/dask_parallel_loop.rst
+++ b/docs/src/user_manual/tutorial/dask_parallel_loop.rst
@@ -8,6 +8,8 @@
 2. Parallelising a Loop of Multiple Calls to a Third Party Library
 ------------------------------------------------------------------
 
+.. readingtime::
+
 Whilst Iris does provide extensive functionality for performing statistical and
 mathematical operations on your data, it is sometimes necessary to use a third
 party library.

--- a/docs/src/user_manual/tutorial/dask_pp_to_netcdf.rst
+++ b/docs/src/user_manual/tutorial/dask_pp_to_netcdf.rst
@@ -9,6 +9,8 @@
 1. Speed up Converting PP Files to NetCDF
 -----------------------------------------
 
+.. readingtime::
+
 Here is an example of how dask objects can be tuned for better performance.
 
 1.1 The Problem - Slow Saving

--- a/docs/src/user_manual/tutorial/interpolation_and_regridding.rst
+++ b/docs/src/user_manual/tutorial/interpolation_and_regridding.rst
@@ -17,6 +17,8 @@
 Cube Interpolation and Regridding
 =================================
 
+.. readingtime::
+
 Iris provides powerful cube-aware interpolation and regridding functionality,
 exposed through Iris cube methods. This functionality is provided by building
 upon existing interpolation schemes implemented by SciPy.

--- a/docs/src/user_manual/tutorial/loading_iris_cubes.rst
+++ b/docs/src/user_manual/tutorial/loading_iris_cubes.rst
@@ -9,6 +9,8 @@
 Loading Iris Cubes
 ===================
 
+.. readingtime::
+
 To load a single file into a **list** of Iris cubes
 the :py:func:`iris.load` function is used::
 

--- a/docs/src/user_manual/tutorial/merge_and_concat.rst
+++ b/docs/src/user_manual/tutorial/merge_and_concat.rst
@@ -9,6 +9,8 @@
 Merge and Concatenate
 =====================
 
+.. readingtime::
+
 We saw in the :doc:`loading_iris_cubes` chapter that Iris tries to load as few cubes as
 possible. This is done by collecting together multiple fields with a shared standard
 name (and other key metadata) into a single multidimensional cube. The processes that

--- a/docs/src/user_manual/tutorial/plotting_a_cube.rst
+++ b/docs/src/user_manual/tutorial/plotting_a_cube.rst
@@ -9,6 +9,8 @@
 Plotting a Cube
 ===============
 
+.. readingtime::
+
 Iris utilises the power of Python's 
 `Matplotlib <https://matplotlib.org/>`_ package in order to generate 
 high quality, production ready 1D and 2D plots. 

--- a/docs/src/user_manual/tutorial/s3_io.rst
+++ b/docs/src/user_manual/tutorial/s3_io.rst
@@ -8,6 +8,8 @@
 Loading From and Saving To S3 Buckets
 =====================================
 
+.. readingtime::
+
 For cloud computing, it is natural to want to access data storage based on URIs.
 At the present time, by far the most widely used platform for this is
 `Amazon S3 "buckets" <https://aws.amazon.com/s3/>`_.

--- a/docs/src/user_manual/tutorial/saving_iris_cubes.rst
+++ b/docs/src/user_manual/tutorial/saving_iris_cubes.rst
@@ -9,6 +9,8 @@
 Saving Iris Cubes
 ==================
 
+.. readingtime::
+
 Iris supports the saving of cubes and cube lists to:
 
 * CF netCDF (version 1.7)

--- a/docs/src/user_manual/tutorial/subsetting_a_cube.rst
+++ b/docs/src/user_manual/tutorial/subsetting_a_cube.rst
@@ -11,6 +11,8 @@
 Subsetting a Cube
 =================
 
+.. readingtime::
+
 The :doc:`loading_iris_cubes` section of the user guide showed how to load data into multidimensional Iris cubes.
 However it is often necessary to reduce the dimensionality of a cube down to something more appropriate and/or manageable,
 or only examine and analyse a subset of data in a dimension.

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -86,6 +86,7 @@ This document explains the changes made to Iris for this release
 #. `@tkknight`_ added a dependency named sphinx-sitemap to generate sitemap.xml for
    the documentaiton. (:pull:`7100`)
 
+
 📚 Documentation
 ================
 
@@ -113,6 +114,11 @@ This document explains the changes made to Iris for this release
    :func:`iris.analysis.cartography.area_weights` requires 1-dimensional lat and lon 
    coordinates on the input :class:`~iris.cube.Cube`. (:pull:`7118`)
 
+#. :user:`bjlittle` Added the custom `sphinx`_ ``readingtime`` directive to
+   automatically estimate the audiance reading time of a page and render a
+   branded banner in-situ. (:pull:`7150`)
+
+
 💼 Internal
 ===========
 
@@ -124,7 +130,6 @@ This document explains the changes made to Iris for this release
 #. `@trexfeathers`_ fixed the benchmarking ``asv_delegated.py`` to work with
    Nox release ``2026.04.10`` (which adds more files to the environment parent
    directory, breaking previous assumptions). (:pull:`7046`)
-
 
 #. `@ESadek-MO` and `@pp-mo`_ removed unit test reliance on all optional dependencies
    except for mo_pack.
@@ -139,7 +144,7 @@ This document explains the changes made to Iris for this release
 
 #. `@trexfeathers` set the link checking workflow to accept redirect HTTP codes, as
    the reports were getting too noisy. (:pull:`7148`)
-   
+
 #. `@HGWright`_ changed the default of the private switch :obj:`~iris.loading._LAZY_DERIVED_LOADING` (formerly `.CONCRETE_DERIVED_LOADING`)
    for controlling laziness of coordinates from pp loading, now the switch must be set to True for lazy loading to be enabled.
    Note: this object is temporary and is likely to be replaced by a permanent solution or else be renamed.


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

Adds the custom `sphinx` directive `readingtime` to calculate the estimated reading time of a documentation page and renders a branded banner in-situ e.g.,

<img width="386" height="178" alt="image" src="https://github.com/user-attachments/assets/c12e35cd-0ce1-4d13-9f14-5732cda30ad2" />

Also includes supporting developer usage documentation.

> [!NOTE]
> The `readingtime` banner colours of turquoise (`#1B8Fb7`) and lime (`#CADC6D`) are sampled from the themed `iris` documentation landing-page icons.

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)

---
Add any of the below labels to trigger actions on this PR:

- https://github.com/SciTools/iris/labels/benchmark_this
