### PR TITLE
TST: correct skip_plot marker

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -177,6 +177,8 @@ This document explains the changes made to Iris for this release
    Note: this object is temporary and is likely to be replaced by a permanent solution or else be renamed.
    (:issue:`7094`, :pull:`7134`)
 
+#. `@rcomer`_ fixed the capitalisation of a pytest marker. (:pull:`7163`)
+
 .. comment
     Whatsnew author names (@github name) in alphabetical order. Note that,
     core dev names are automatically included by the common_links.inc:

--- a/lib/iris/tests/graphics/__init__.py
+++ b/lib/iris/tests/graphics/__init__.py
@@ -285,7 +285,7 @@ def skip_plot(fn: Callable) -> Callable:
     ...     pass
 
     """
-    skip = pytest.mark.skipIf(
+    skip = pytest.mark.skipif(
         condition=not MPL_AVAILABLE,
         reason="Graphics tests require the matplotlib library.",
     )


### PR DESCRIPTION
## Description

Pytest just fixed a bug whereby the `--strict-markers` option was being ignored https://github.com/pytest-dev/pytest/pull/14443

#7162 is therefore failing because `skipIf` is an unknown marker.  I assume it should be [skipif](https://docs.pytest.org/en/stable/reference/reference.html#pytest-mark-skipif).  I attempted to make a Matplotlib-less dev environment to check that this now works, but found that you can't even `import iris.cube` without Cartopy being installed, and Matplotlib has been a required dependency of Cartopy for a while now.

```
    import iris.cube
lib/iris/cube.py:42: in <module>
    import iris._merge
lib/iris/_merge.py:28: in <module>
    import iris.coords
lib/iris/coords.py:40: in <module>
    import iris.util
lib/iris/util.py:40: in <module>
    from iris.coord_systems import GeogCS
lib/iris/coord_systems.py:19: in <module>
    import cartopy.crs as ccrs
E   ModuleNotFoundError: No module named 'cartopy'
```

## Checklist

> [!IMPORTANT]
> **The Iris core developers are here to help!** If anything below is unclear, just post a comment asking for help 😊

- [x] Included a [**What's New**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/documenting/whats_new_contributions.html) entry
- [x] Incorporated [**type hints**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_code_formatting.html#type-hinting) in any changed code
- [x] Checked if [**tests**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_tests.html) need updating
- [x] Checked if [**benchmarks**](../benchmarks/README.md#writing-benchmarks) need updating
- [x] Checked if **documentation** needs updating
  - [Docstrings](https://scitools-iris.readthedocs.io/en/latest/developers_guide/documenting/docstrings.html) (we love code examples!)
  - [User Manual](https://scitools-iris.readthedocs.io/en/latest/user_manual/) pages
- [x] Checked if [**dependencies**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_ci_tests.html#gha-test-env) need updating
- [x] Confirmed that the GitHub **'checks'** on this PR are passing :white_check_mark:
  _([further reading](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_ci_tests.html))_

---
> [!TIP]
> Things you can trigger on this PR:
>
> - Add this label to trigger benchmarks: https://github.com/SciTools/iris/labels/benchmark_this
> - Visit this URL - swapping `9999` for this PR's number - to re-trigger the [CLA check](https://github.com/SciTools/.github/wiki/Contributor-Licence-Agreement):
>   `https://cla-assistant.io/check/SciTools/iris?pullRequest=9999`
