### PR TITLE
Fix benchmarks link in PR checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@ _Please describe your awesome pull request_
 - [ ] Included a [**What's New**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/documenting/whats_new_contributions.html) entry
 - [ ] Incorporated [**type hints**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_code_formatting.html#type-hinting) in any changed code
 - [ ] Checked if [**tests**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_tests.html) need updating
-- [ ] Checked if [**benchmarks**](../benchmarks/README.md#writing-benchmarks) need updating
+- [ ] Checked if [**benchmarks**](https://github.com/SciTools/iris/blob/main/benchmarks/README.md#writing-benchmarks) need updating
 - [ ] Checked if **documentation** needs updating
   - [Docstrings](https://scitools-iris.readthedocs.io/en/latest/developers_guide/documenting/docstrings.html) (we love code examples!)
   - [User Manual](https://scitools-iris.readthedocs.io/en/latest/user_manual/) pages

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -124,7 +124,7 @@ This document explains the changes made to Iris for this release
 
 #. `@trexfeathers`_ simplified the pull request checklist and moved it directly
    into the GitHub pull request template (read more here: :ref:`pr_check`). Also
-   updated several associated pages of more detailed guidance. (:pull:`7096`, :pull:`7163`)
+   updated several associated pages of more detailed guidance. (:pull:`7096`, :pull:`7164`)
 
 #. `@tkknight`_ updated the documentation to generate summaries
    that LLMs can understand, `llms.txt` and `llms-full.txt`. (:pull:`7105`)

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -124,7 +124,8 @@ This document explains the changes made to Iris for this release
 
 #. `@trexfeathers`_ simplified the pull request checklist and moved it directly
    into the GitHub pull request template (read more here: :ref:`pr_check`). Also
-   updated several associated pages of more detailed guidance. (:pull:`7096`)
+   updated several associated pages of more detailed guidance. (:pull:`7096`, :pull:`7163`)
+
 #. `@tkknight`_ updated the documentation to generate summaries
    that LLMs can understand, `llms.txt` and `llms-full.txt`. (:pull:`7105`)
 


### PR DESCRIPTION
## Description

Was previously using `..` relative notation, but visiting a file in GitHub actually requires a `blob` URL.

## Checklist

> [!IMPORTANT]
> **The Iris core developers are here to help!** If anything below is unclear, just post a comment asking for help 😊

- [x] Included a [**What's New**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/documenting/whats_new_contributions.html) entry
- [x] Incorporated [**type hints**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_code_formatting.html#type-hinting) in any changed code
- [x] Checked if [**tests**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_tests.html) need updating
- [x] Checked if [**benchmarks**](../benchmarks/README.md#writing-benchmarks) need updating
- [x] Checked if **documentation** needs updating
  - [Docstrings](https://scitools-iris.readthedocs.io/en/latest/developers_guide/documenting/docstrings.html) (we love code examples!)
  - [User Manual](https://scitools-iris.readthedocs.io/en/latest/user_manual/) pages
- [x] Checked if [**dependencies**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_ci_tests.html#gha-test-env) need updating
- [x] Confirmed that the GitHub **'checks'** on this PR are passing :white_check_mark:
  _([further reading](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_ci_tests.html))_

---
> [!TIP]
> Things you can trigger on this PR:
>
> - Add this label to trigger benchmarks: https://github.com/SciTools/iris/labels/benchmark_this
> - Visit this URL - swapping `9999` for this PR's number - to re-trigger the [CLA check](https://github.com/SciTools/.github/wiki/Contributor-Licence-Agreement):
>   `https://cla-assistant.io/check/SciTools/iris?pullRequest=9999`
