### PR TITLE
Include lychee defaults in the `--accept` argument

### DIFF
--- a/.github/workflows/ci-linkchecks.yml
+++ b/.github/workflows/ci-linkchecks.yml
@@ -35,7 +35,7 @@ jobs:
           args: |
             --verbose
             --max-concurrency 1
-            --accept 301,302,307,308
+            --accept 100..=103,200..=299,301,302,307,308
             './docs/**/*.rst'
             './docs/**/*.inc'
             './lib/**/*.py'

--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -170,7 +170,7 @@ This document explains the changes made to Iris for this release
    Zizmor's recommendations to harden the workflows. (:pull:`7138`)
 
 #. `@trexfeathers` set the link checking workflow to accept redirect HTTP codes, as
-   the reports were getting too noisy. (:pull:`7148`)
+   the reports were getting too noisy. (:pull:`7148`, :pull:`7165`)
 
 #. `@HGWright`_ changed the default of the private switch :obj:`~iris.loading._LAZY_DERIVED_LOADING` (formerly `.CONCRETE_DERIVED_LOADING`)
    for controlling laziness of coordinates from pp loading, now the switch must be set to True for lazy loading to be enabled.


### PR DESCRIPTION
## Description

#7148 unintentionally excluded the original Lychee defaults.

## Checklist

> [!IMPORTANT]
> **The Iris core developers are here to help!** If anything below is unclear, just post a comment asking for help 😊

- [x] Included a [**What's New**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/documenting/whats_new_contributions.html) entry
- [x] Incorporated [**type hints**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_code_formatting.html#type-hinting) in any changed code
- [x] Checked if [**tests**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_tests.html) need updating
- [x] Checked if [**benchmarks**](../benchmarks/README.md#writing-benchmarks) need updating
- [x] Checked if **documentation** needs updating
  - [Docstrings](https://scitools-iris.readthedocs.io/en/latest/developers_guide/documenting/docstrings.html) (we love code examples!)
  - [User Manual](https://scitools-iris.readthedocs.io/en/latest/user_manual/) pages
- [x] Checked if [**dependencies**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_ci_tests.html#gha-test-env) need updating
- [x] Confirmed that the GitHub **'checks'** on this PR are passing :white_check_mark:
  _([further reading](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_ci_tests.html))_

---
> [!TIP]
> Things you can trigger on this PR:
>
> - Add this label to trigger benchmarks: https://github.com/SciTools/iris/labels/benchmark_this
> - Visit this URL - swapping `9999` for this PR's number - to re-trigger the [CLA check](https://github.com/SciTools/.github/wiki/Contributor-Licence-Agreement):
>   `https://cla-assistant.io/check/SciTools/iris?pullRequest=9999`
