### PR TITLE
Moved duplicated code into setup

### DIFF
--- a/changelog/7188.internal.rst
+++ b/changelog/7188.internal.rst
@@ -1,2 +1,2 @@
-:user:`GitRylee` moved duplicated code in :class:`iris.tests.unit.analysis.trajectory.test__nearest_neighbour_indices_ndcoords.TestApiExtras`
+:user:`GitRylee` moved duplicated code in ``iris.tests.unit.analysis.trajectory.test__nearest_neighbour_indices_ndcoords``
 to a setup fixture. (:issue:`6625`)

--- a/changelog/7188.internal.rst
+++ b/changelog/7188.internal.rst
@@ -1,0 +1,2 @@
+:user:`GitRylee` moved duplicated code in :class:`iris.tests.unit.analysis.trajectory.test__nearest_neighbour_indices_ndcoords.TestApiExtras`
+to a setup fixture. (:issue:`6625`)

--- a/lib/iris/tests/unit/analysis/trajectory/test__nearest_neighbour_indices_ndcoords.py
+++ b/lib/iris/tests/unit/analysis/trajectory/test__nearest_neighbour_indices_ndcoords.py
@@ -93,39 +93,40 @@ class Test1d:
 
 class TestApiExtras:
     # Check operation with alternative calling setups.
+
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        self.co_x = DimCoord([1.0, 2.0, 3.0], long_name="x")
+        self.co_y = DimCoord([10.0, 20.0], long_name="y")
+        self.cube = Cube(np.zeros((2, 3)))
+
     def test_no_y_dim(self):
         # Operate in X only, returned slice should be [:, ix].
-        co_x = DimCoord([1.0, 2.0, 3.0], long_name="x")
-        co_y = DimCoord([10.0, 20.0], long_name="y")
-        cube = Cube(np.zeros((2, 3)))
-        cube.add_dim_coord(co_y, 0)
-        cube.add_dim_coord(co_x, 1)
+
+        self.cube.add_dim_coord(self.co_y, 0)
+        self.cube.add_dim_coord(self.co_x, 1)
         sample_point = [("x", 2.8)]
-        result = nn_ndinds(cube, sample_point)
+        result = nn_ndinds(self.cube, sample_point)
         assert result == [(slice(None), 2)]
 
     def test_no_x_dim(self):
         # Operate in Y only, returned slice should be [iy, :].
-        co_x = DimCoord([1.0, 2.0, 3.0], long_name="x")
-        co_y = DimCoord([10.0, 20.0], long_name="y")
-        cube = Cube(np.zeros((2, 3)))
-        cube.add_dim_coord(co_y, 0)
-        cube.add_dim_coord(co_x, 1)
+
+        self.cube.add_dim_coord(self.co_y, 0)
+        self.cube.add_dim_coord(self.co_x, 1)
         sample_point = [("y", 18.5)]
-        result = nn_ndinds(cube, sample_point)
+        result = nn_ndinds(self.cube, sample_point)
         assert result == [(1, slice(None))]
 
     def test_sample_dictionary(self):
         # Pass sample_point arg as a dictionary: this usage mode is deprecated.
-        co_x = AuxCoord([1.0, 2.0, 3.0], long_name="x")
-        co_y = AuxCoord([10.0, 20.0], long_name="y")
-        cube = Cube(np.zeros((2, 3)))
-        cube.add_aux_coord(co_y, 0)
-        cube.add_aux_coord(co_x, 1)
+
+        self.cube.add_aux_coord(self.co_y, 0)
+        self.cube.add_aux_coord(self.co_x, 1)
         sample_point = {"x": 2.8, "y": 18.5}
         exp_emsg = r"must be a list of \(coordinate, value\) pairs"
         with pytest.raises(TypeError, match=exp_emsg):
-            nn_ndinds(cube, sample_point)
+            nn_ndinds(self.cube, sample_point)
 
 
 class TestLatlon:


### PR DESCRIPTION
## Description

Part of #6625 
I've moved all of the duplicated code into the setup.

## Checklist

> [!IMPORTANT]
> **The Iris core developers are here to help!** If anything below is unclear, just post a comment asking for help 😊

- [x] Included a [**What's New**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/documenting/whats_new_contributions.html) entry
- [x] Incorporated [**type hints**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_code_formatting.html#type-hinting) in any changed code
- [x] Checked if [**tests**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_tests.html) need updating
- [x] Checked if [**benchmarks**](../benchmarks/README.md#writing-benchmarks) need updating
- [x] Checked if **documentation** needs updating
  - [Docstrings](https://scitools-iris.readthedocs.io/en/latest/developers_guide/documenting/docstrings.html) (we love code examples!)
  - [User Manual](https://scitools-iris.readthedocs.io/en/latest/user_manual/) pages
- [x] Checked if [**dependencies**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_ci_tests.html#gha-test-env) need updating
- [x] Confirmed that the GitHub **'checks'** on this PR are passing :white_check_mark:
  _([further reading](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_ci_tests.html))_

---
> [!TIP]
> Things you can trigger on this PR:
>
> - Add this label to trigger benchmarks: https://github.com/SciTools/iris/labels/benchmark_this
> - Visit this URL - swapping `9999` for this PR's number - to re-trigger the [CLA check](https://github.com/SciTools/.github/wiki/Contributor-Licence-Agreement):
>   `https://cla-assistant.io/check/SciTools/iris?pullRequest=9999`
