### PR TITLE
Removed commented codes from test_CFReader

### DIFF
--- a/changelog/7189.internal.rst
+++ b/changelog/7189.internal.rst
@@ -1,0 +1,1 @@
+:user:`king56180468-droid` removed redundant commented codes from ``test_CFReader``. (:issue:`6625`)

--- a/lib/iris/tests/unit/fileformats/cf/test_CFReader.py
+++ b/lib/iris/tests/unit/fileformats/cf/test_CFReader.py
@@ -369,10 +369,6 @@ class Test_build_cf_groups__ugrid:
             file_format="NetCDF4", variables=self.variables, ncattrs=ncattrs
         )
 
-        # @pytest.fixture(autouse=True)
-        # def _setup(self, mocker):
-        # Restrict the CFReader functionality to only performing
-        # translations and building first level cf-groups for variables.
         mocker.patch("iris.fileformats.cf.CFReader._reset")
         mocker.patch(
             "iris.fileformats.netcdf._thread_safe_nc.DatasetWrapper",

--- a/lib/iris/tests/unit/fileformats/cf/test_CFReader.py
+++ b/lib/iris/tests/unit/fileformats/cf/test_CFReader.py
@@ -369,6 +369,8 @@ class Test_build_cf_groups__ugrid:
             file_format="NetCDF4", variables=self.variables, ncattrs=ncattrs
         )
 
+        # Restrict the CFReader functionality to only performing
+        # translations and building first level cf-groups for variables.
         mocker.patch("iris.fileformats.cf.CFReader._reset")
         mocker.patch(
             "iris.fileformats.netcdf._thread_safe_nc.DatasetWrapper",


### PR DESCRIPTION
## Description

The comments are unnecessary , so I deleted those commented codes.
Part of #6625 
## Checklist

> [!IMPORTANT]
> **The Iris core developers are here to help!** If anything below is unclear, just post a comment asking for help 😊

- [x] Included a [**What's New**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/documenting/whats_new_contributions.html) entry
- [x] Incorporated [**type hints**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_code_formatting.html#type-hinting) in any changed code
- [x] Checked if [**tests**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_tests.html) need updating
- [x] Checked if [**benchmarks**](../benchmarks/README.md#writing-benchmarks) need updating
- [x] Checked if **documentation** needs updating
  - [Docstrings](https://scitools-iris.readthedocs.io/en/latest/developers_guide/documenting/docstrings.html) (we love code examples!)
  - [User Manual](https://scitools-iris.readthedocs.io/en/latest/user_manual/) pages
- [x] Checked if [**dependencies**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_ci_tests.html#gha-test-env) need updating
- [x] Confirmed that the GitHub **'checks'** on this PR are passing :white_check_mark:
  _([further reading](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_ci_tests.html))_

---
> [!TIP]
> Things you can trigger on this PR:
>
> - Add this label to trigger benchmarks: https://github.com/SciTools/iris/labels/benchmark_this
> - Visit this URL - swapping `9999` for this PR's number - to re-trigger the [CLA check](https://github.com/SciTools/.github/wiki/Contributor-Licence-Agreement):
>   `https://cla-assistant.io/check/SciTools/iris?pullRequest=9999`
