### PR TITLE
Partial improvement of test class names

### DIFF
--- a/changelog/7190.internal.rst
+++ b/changelog/7190.internal.rst
@@ -1,0 +1,1 @@
+:user:`2319bli` has partially improved the names of various test classes. (:issue:`6625`)

--- a/lib/iris/tests/integration/test_PartialDateTime.py
+++ b/lib/iris/tests/integration/test_PartialDateTime.py
@@ -9,7 +9,7 @@ from iris.tests import _shared_utils
 from iris.time import PartialDateTime
 
 
-class Test:
+class TestPartialDateTime:
     @_shared_utils.skip_data
     def test_cftime_interface(self):
         # The `netcdf4` Python module introduced new calendar classes by v1.2.7

--- a/lib/iris/tests/unit/analysis/cartography/test_wrap_lons.py
+++ b/lib/iris/tests/unit/analysis/cartography/test_wrap_lons.py
@@ -12,7 +12,7 @@ import pytest
 from iris.analysis.cartography import wrap_lons
 
 
-class Test:
+class TestWrapLons:
     def test_values(self):
         # The documented behaviour (matches the docstring example).
         result = wrap_lons(np.array([185, 30, -200, 75]), -180, 360)

--- a/lib/iris/tests/unit/analysis/maths/test__get_dtype.py
+++ b/lib/iris/tests/unit/analysis/maths/test__get_dtype.py
@@ -12,7 +12,7 @@ from iris.coords import AuxCoord, DimCoord
 from iris.cube import Cube
 
 
-class Test:
+class TestGetDtype:
     def _check_call(self, obj, expected_dtype):
         result = _get_dtype(obj)
         assert expected_dtype == result

--- a/lib/iris/tests/unit/analysis/test_PercentileAggregator.py
+++ b/lib/iris/tests/unit/analysis/test_PercentileAggregator.py
@@ -15,7 +15,7 @@ from iris.cube import Cube
 from iris.tests import _shared_utils
 
 
-class Test:
+class TestPercentileAggregator:
     def test_init(self, mocker):
         name = "percentile"
         units_func = mocker.sentinel.units_func

--- a/lib/iris/tests/unit/common/lenient/test__qualname.py
+++ b/lib/iris/tests/unit/common/lenient/test__qualname.py
@@ -11,7 +11,7 @@ import pytest
 from iris.common.lenient import _qualname
 
 
-class TestQualname:
+class Test:
     @pytest.fixture(autouse=True)
     def _setup(self):
         module_name = getmodule(self).__name__

--- a/lib/iris/tests/unit/common/lenient/test__qualname.py
+++ b/lib/iris/tests/unit/common/lenient/test__qualname.py
@@ -11,7 +11,7 @@ import pytest
 from iris.common.lenient import _qualname
 
 
-class Test:
+class TestQualname:
     @pytest.fixture(autouse=True)
     def _setup(self):
         module_name = getmodule(self).__name__

--- a/lib/iris/tests/unit/common/metadata/test__NamedTupleMeta.py
+++ b/lib/iris/tests/unit/common/metadata/test__NamedTupleMeta.py
@@ -11,7 +11,7 @@ import pytest
 from iris.common.metadata import _NamedTupleMeta
 
 
-class Test:
+class TestNamedTupleMeta:
     @staticmethod
     def names(classes):
         return [cls.__name__ for cls in classes]

--- a/lib/iris/tests/unit/common/mixin/test_LimitedAttributeDict.py
+++ b/lib/iris/tests/unit/common/mixin/test_LimitedAttributeDict.py
@@ -10,7 +10,7 @@ import pytest
 from iris.common.mixin import LimitedAttributeDict
 
 
-class Test:
+class TestLimitedAttributeDict:
     @pytest.fixture(autouse=True)
     def _setup(self):
         self.forbidden_keys = LimitedAttributeDict.CF_ATTRS_FORBIDDEN

--- a/lib/iris/tests/unit/coord_systems/test_Geostationary.py
+++ b/lib/iris/tests/unit/coord_systems/test_Geostationary.py
@@ -11,7 +11,7 @@ from iris.coord_systems import GeogCS, Geostationary
 from iris.tests import _shared_utils
 
 
-class Test:
+class TestGeostationary:
     @pytest.fixture(autouse=True)
     def _setup(self):
         # Set everything to non-default values.

--- a/lib/iris/tests/unit/coord_systems/test_VerticalPerspective.py
+++ b/lib/iris/tests/unit/coord_systems/test_VerticalPerspective.py
@@ -11,7 +11,7 @@ from iris.coord_systems import GeogCS, VerticalPerspective
 from iris.tests import _shared_utils
 
 
-class Test:
+class TestVerticalPerspective:
     @pytest.fixture(autouse=True)
     def _setup(self):
         self.latitude_of_projection_origin = 0.0

--- a/lib/iris/tests/unit/fileformats/dot/test__dot_path.py
+++ b/lib/iris/tests/unit/fileformats/dot/test__dot_path.py
@@ -12,7 +12,7 @@ import pytest
 from iris.fileformats.dot import _DOT_EXECUTABLE_PATH, _dot_path
 
 
-class Test:
+class TestDotPath:
     @pytest.fixture(autouse=True)
     def _setup(self, mocker):
         # Because _dot_path is triggered by the initial import we

--- a/lib/iris/tests/unit/fileformats/ff/test_ENDGame.py
+++ b/lib/iris/tests/unit/fileformats/ff/test_ENDGame.py
@@ -10,7 +10,7 @@ from iris.fileformats._ff import ENDGame
 from iris.tests import _shared_utils
 
 
-class Test:
+class TestENDGame:
     def test_class_attributes(self):
         reals = np.arange(6) + 100
         grid = ENDGame(None, None, reals, None)

--- a/lib/iris/tests/unit/fileformats/ff/test_NewDynamics.py
+++ b/lib/iris/tests/unit/fileformats/ff/test_NewDynamics.py
@@ -10,7 +10,7 @@ from iris.fileformats._ff import NewDynamics
 from iris.tests import _shared_utils
 
 
-class Test:
+class TestNewDynamics:
     def test_class_attributes(self):
         reals = np.arange(6) + 100
         grid = NewDynamics(None, None, reals, None)

--- a/lib/iris/tests/unit/fileformats/nimrod_load_rules/test_vertical_coord.py
+++ b/lib/iris/tests/unit/fileformats/nimrod_load_rules/test_vertical_coord.py
@@ -18,7 +18,7 @@ from iris.fileformats.nimrod_load_rules import (
 from iris.tests._shared_utils import assert_no_warnings_regexp
 
 
-class Test:
+class TestVerticalCoord:
     @pytest.fixture(autouse=True)
     def _setup(self, mocker):
         self.field = mocker.Mock(

--- a/lib/iris/tests/unit/fileformats/pp/test__field_gen.py
+++ b/lib/iris/tests/unit/fileformats/pp/test__field_gen.py
@@ -21,7 +21,7 @@ _HEADER_BYTES = pp.PP_WORD_DEPTH * (1 + pp.NUM_LONG_HEADERS + pp.NUM_FLOAT_HEADE
 _DATA_LEN_WORD = struct.pack(">L", 4)
 
 
-class Test:
+class TestFieldGen:
     @pytest.fixture
     def mock_for_field_gen(self, mocker):
         @contextlib.contextmanager

--- a/lib/iris/tests/unit/plot/test_hist.py
+++ b/lib/iris/tests/unit/plot/test_hist.py
@@ -16,7 +16,7 @@ if _shared_utils.MPL_AVAILABLE:
 
 
 @_shared_utils.skip_plot
-class Test:
+class TestHist:
     @pytest.fixture(autouse=True)
     def _create_data(self):
         self.data = np.array([0, 100, 110, 120, 200, 320])

--- a/lib/iris/tests/unit/util/test__is_circular.py
+++ b/lib/iris/tests/unit/util/test__is_circular.py
@@ -17,7 +17,7 @@ from iris.util import _is_circular
         pytest.param(False, id="without_bounds"),
     ],
 )
-class Test:
+class TestIsCircular:
     @staticmethod
     def _calc_bounds(points):
         diff = np.diff(points).mean()

--- a/lib/iris/tests/unit/util/test_find_discontiguities.py
+++ b/lib/iris/tests/unit/util/test_find_discontiguities.py
@@ -21,7 +21,7 @@ def full2d_global():
 
 
 @_shared_utils.skip_data
-class Test:
+class TestFindDiscontiguities:
     @pytest.fixture(autouse=True)
     def _setup(self):
         # Set up a 2d lat-lon cube with 2d coordinates that have been

--- a/lib/iris/tests/unit/util/test_squeeze.py
+++ b/lib/iris/tests/unit/util/test_squeeze.py
@@ -10,7 +10,7 @@ import iris
 import iris.tests.stock as stock
 
 
-class Test:
+class TestSqueeze:
     @pytest.fixture(autouse=True)
     def _setup(self):
         self.cube = stock.simple_2d_w_multidim_and_scalars()


### PR DESCRIPTION
## Description

Part of #6625.
I have partially changed instances of test classes with the generic name `Test` to a more detailed name.

## Checklist

> [!IMPORTANT]
> **The Iris core developers are here to help!** If anything below is unclear, just post a comment asking for help 😊

- [x] Included a [**What's New**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/documenting/whats_new_contributions.html) entry
- [x] Incorporated [**type hints**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_code_formatting.html#type-hinting) in any changed code
- [x] Checked if [**tests**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_tests.html) need updating
- [x] Checked if [**benchmarks**](../benchmarks/README.md#writing-benchmarks) need updating
- [x] Checked if **documentation** needs updating
  - [Docstrings](https://scitools-iris.readthedocs.io/en/latest/developers_guide/documenting/docstrings.html) (we love code examples!)
  - [User Manual](https://scitools-iris.readthedocs.io/en/latest/user_manual/) pages
- [x] Checked if [**dependencies**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_ci_tests.html#gha-test-env) need updating
- [ ] Confirmed that the GitHub **'checks'** on this PR are passing :white_check_mark:
  _([further reading](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_ci_tests.html))_

---
> [!TIP]
> Things you can trigger on this PR:
>
> - Add this label to trigger benchmarks: https://github.com/SciTools/iris/labels/benchmark_this
> - Visit this URL - swapping `9999` for this PR's number - to re-trigger the [CLA check](https://github.com/SciTools/.github/wiki/Contributor-Licence-Agreement):
>   `https://cla-assistant.io/check/SciTools/iris?pullRequest=9999`
