### PR TITLE
PP saving: always set `lbft` in hours

### DIFF
--- a/changelog/7197.bugfix.rst
+++ b/changelog/7197.bugfix.rst
@@ -1,0 +1,3 @@
+:user:`trexfeathers` and :user:`kwilliams-mo` fixed the saving of PP fields to now 
+always write ``lbft`` in hours in the no-bounds forecast period case, including when 
+``forecast_period`` uses non-hour units such as seconds.

--- a/lib/iris/fileformats/pp_save_rules.py
+++ b/lib/iris/fileformats/pp_save_rules.py
@@ -169,7 +169,7 @@ def _general_time_rules(cube, pp):
         pp.lbtim.ib = 1
         pp.t1 = time_coord.units.num2date(time_coord.points[0])
         pp.t2 = time_coord.units.num2date(time_coord.points[0] - fp_coord.points[0])
-        pp.lbft = fp_coord.points[0]
+        pp.lbft = fp_coord.units.convert(fp_coord.points[0], "hours")
 
     # Time mean (non-climatological).
     # XXX This only works when we have a single timestep.

--- a/lib/iris/tests/unit/fileformats/pp/test_save.py
+++ b/lib/iris/tests/unit/fileformats/pp/test_save.py
@@ -298,6 +298,22 @@ class TestTimeMean:
 
         assert mock_lbft is actual
 
+    def test_lbft_forecast_period_converted_to_hours(self, mocker):
+        cube = stock.realistic_3d()[0:1, :, :]
+        time_coord = cube.coord("time")
+        fp_coord = cube.coord("forecast_period")
+
+        # Hit the no-bounds forecast branch and force non-hour forecast units.
+        time_coord.bounds = None
+        expected_hours = fp_coord.units.convert(fp_coord.points[0], "hours")
+        fp_coord.points = [fp_coord.units.convert(fp_coord.points[0], "seconds")]
+        fp_coord.units = "seconds"
+
+        pp_field = mocker.patch("iris.fileformats.pp.PPField3", autospec=True)
+        verify(cube, pp_field)
+
+        assert pp_field.lbft == pytest.approx(expected_hours)
+
     def test_lbtim_no_time_mean(self, mocker, single_time_cube):
         expected_ib = 0
         expected_ic = 2  # 360 day calendar


### PR DESCRIPTION
## Description

Thanks to @kwilliams-mo for reporting. There was one case of `lbft` writing that was not converting to `hours since ...`, unlike the other 7 cases.

## Checklist

> [!IMPORTANT]
> **The Iris core developers are here to help!** If anything below is unclear, just post a comment asking for help 😊

- [x] Included a [**What's New**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/documenting/whats_new_contributions.html) entry
- [ ] ~~Incorporated [**type hints**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_code_formatting.html#type-hinting) in any changed code~~
  Would have been big scope creep in this case - just one line.
- [x] Checked if [**tests**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_tests.html) need updating
- [x] Checked if [**benchmarks**](../benchmarks/README.md#writing-benchmarks) need updating
- [x] Checked if **documentation** needs updating
  - [Docstrings](https://scitools-iris.readthedocs.io/en/latest/developers_guide/documenting/docstrings.html) (we love code examples!)
  - [User Manual](https://scitools-iris.readthedocs.io/en/latest/user_manual/) pages
- [x] Checked if [**dependencies**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_ci_tests.html#gha-test-env) need updating
- [x] Confirmed that the GitHub **'checks'** on this PR are passing :white_check_mark:
  _([further reading](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_ci_tests.html))_

---
> [!TIP]
> Things you can trigger on this PR:
>
> - Add this label to trigger benchmarks: https://github.com/SciTools/iris/labels/benchmark_this
> - Visit this URL - swapping `9999` for this PR's number - to re-trigger the [CLA check](https://github.com/SciTools/.github/wiki/Contributor-Licence-Agreement):
>   `https://cla-assistant.io/check/SciTools/iris?pullRequest=9999`
