### PR TITLE
Fix type hints for `iris.cube.Cube` arguments

### DIFF
--- a/changelog/7202.doc.rst
+++ b/changelog/7202.doc.rst
@@ -1,1 +1,1 @@
-:user:`bouweandela` Fixed the type hints for the :method:`iris.cube.Cube.__init__`.
+:user:`bouweandela` Fixed the type hints for the :meth:`iris.cube.Cube.__init__`.

--- a/changelog/7202.doc.rst
+++ b/changelog/7202.doc.rst
@@ -1,0 +1,1 @@
+:user:`bouweandela` Fixed the type hints for the :method:`iris.cube.Cube.__init__`.

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1212,14 +1212,33 @@ class Cube(CFVariableMixin):
         units: Unit | str | None = None,
         attributes: Mapping | None = None,
         cell_methods: Iterable[CellMethod] | None = None,
-        dim_coords_and_dims: Iterable[tuple[DimCoord, int]] | None = None,
-        aux_coords_and_dims: Iterable[tuple[AuxCoord, int | Iterable[int] | None]]
+        dim_coords_and_dims: Iterable[
+            tuple[
+                DimCoord,
+                int,
+            ],
+        ]
+        | None = None,
+        aux_coords_and_dims: Iterable[
+            tuple[
+                AuxCoord,
+                int | Iterable[int] | None,
+            ],
+        ]
         | None = None,
         aux_factories: Iterable[AuxCoordFactory] | None = None,
-        cell_measures_and_dims: Iterable[tuple[CellMeasure, Iterable[int] | int | None]]
+        cell_measures_and_dims: Iterable[
+            tuple[
+                CellMeasure,
+                Iterable[int] | int | None,
+            ],
+        ]
         | None = None,
         ancillary_variables_and_dims: Iterable[
-            tuple[AncillaryVariable, Iterable[int] | int | None]
+            tuple[
+                AncillaryVariable,
+                Iterable[int] | int | None,
+            ],
         ]
         | None = None,
         shape: tuple | None = None,

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1221,7 +1221,7 @@ class Cube(CFVariableMixin):
         | None = None,
         aux_coords_and_dims: Iterable[
             tuple[
-                AuxCoord,
+                AuxCoord | DimCoord,
                 int | Iterable[int] | None,
             ],
         ]

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1213,11 +1213,14 @@ class Cube(CFVariableMixin):
         attributes: Mapping | None = None,
         cell_methods: Iterable[CellMethod] | None = None,
         dim_coords_and_dims: Iterable[tuple[DimCoord, int]] | None = None,
-        aux_coords_and_dims: Iterable[tuple[AuxCoord, int | Iterable[int]]]
+        aux_coords_and_dims: Iterable[tuple[AuxCoord, int | Iterable[int] | None]]
         | None = None,
         aux_factories: Iterable[AuxCoordFactory] | None = None,
-        cell_measures_and_dims: Iterable[tuple[CellMeasure, int]] | None = None,
-        ancillary_variables_and_dims: Iterable[tuple[AncillaryVariable, int]]
+        cell_measures_and_dims: Iterable[tuple[CellMeasure, Iterable[int] | int | None]]
+        | None = None,
+        ancillary_variables_and_dims: Iterable[
+            tuple[AncillaryVariable, Iterable[int] | int | None]
+        ]
         | None = None,
         shape: tuple | None = None,
     ):


### PR DESCRIPTION
## Description

The arguments `aux_coords_and_dims`, `cell_measures_and_dims`, and `ancillary_variables_and_dims` to `iris.cube.Cube` are missing some valid input types. This pull requests adds them. I was not sure what the right category for type hints was, so I opted for `doc`. Please let me know if it needs to be something else.
 
## Checklist

> [!IMPORTANT]
> **The Iris core developers are here to help!** If anything below is unclear, just post a comment asking for help 😊

- [x] Included a [**What's New**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/documenting/whats_new_contributions.html) entry
- [x] Incorporated [**type hints**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_code_formatting.html#type-hinting) in any changed code
- [x] Checked if [**tests**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_tests.html) need updating
- [x] Checked if [**benchmarks**](../benchmarks/README.md#writing-benchmarks) need updating
- [x] Checked if **documentation** needs updating
  - [Docstrings](https://scitools-iris.readthedocs.io/en/latest/developers_guide/documenting/docstrings.html) (we love code examples!)
  - [User Manual](https://scitools-iris.readthedocs.io/en/latest/user_manual/) pages
- [x] Checked if [**dependencies**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_ci_tests.html#gha-test-env) need updating
- [x] Confirmed that the GitHub **'checks'** on this PR are passing :white_check_mark:
  _([further reading](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_ci_tests.html))_

---
> [!TIP]
> Things you can trigger on this PR:
>
> - Add this label to trigger benchmarks: https://github.com/SciTools/iris/labels/benchmark_this
> - Visit this URL - swapping `9999` for this PR's number - to re-trigger the [CLA check](https://github.com/SciTools/.github/wiki/Contributor-Licence-Agreement):
>   `https://cla-assistant.io/check/SciTools/iris?pullRequest=9999`
