### PR TITLE
ruff compliance for TC

### DIFF
--- a/changelog/7203.internal.rst
+++ b/changelog/7203.internal.rst
@@ -1,1 +1,1 @@
-:user:`bouweandela` enabled [Ruff type checking (TC) rules](https://docs.astral.sh/ruff/rules/#flake8-type-checking-tc).
+:user:`bouweandela` enabled `Ruff type checking (TC) rules <https://docs.astral.sh/ruff/rules/#flake8-type-checking-tc>`_.

--- a/changelog/7203.internal.rst
+++ b/changelog/7203.internal.rst
@@ -1,0 +1,1 @@
+:user:`bouweandela` enabled [Ruff type checking (TC) rules](https://docs.astral.sh/ruff/rules/#flake8-type-checking-tc).

--- a/lib/iris/_lazy_data.py
+++ b/lib/iris/_lazy_data.py
@@ -9,8 +9,7 @@ To avoid replicating implementation-dependent test and conversion code.
 """
 
 from functools import lru_cache, partial, wraps
-from types import ModuleType
-from typing import Sequence
+from typing import TYPE_CHECKING, Sequence
 
 import dask
 import dask.array as da
@@ -20,6 +19,9 @@ import numpy as np
 import numpy.ma as ma
 
 import iris.exceptions
+
+if TYPE_CHECKING:
+    from types import ModuleType
 
 MAX_CACHE_SIZE = 100
 """Maximum number of Dask arrays to cache."""

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -45,8 +45,7 @@ import functools
 from functools import wraps
 from inspect import getfullargspec
 import itertools
-from numbers import Number
-from typing import Optional, Protocol, Union
+from typing import TYPE_CHECKING, Optional, Protocol, Union
 import warnings
 
 from cf_units import Unit
@@ -64,6 +63,9 @@ import iris.coords
 from iris.coords import AuxCoord, DimCoord, _DimensionalMetadata
 from iris.exceptions import LazyAggregatorError
 import iris.util
+
+if TYPE_CHECKING:
+    from numbers import Number
 
 __all__ = (
     "Aggregator",

--- a/lib/iris/common/metadata.py
+++ b/lib/iris/common/metadata.py
@@ -20,12 +20,13 @@ from functools import lru_cache, wraps
 import re
 from typing import TYPE_CHECKING, Any
 
-import cf_units
 import numpy as np
 import numpy.ma as ma
 from xxhash import xxh64_hexdigest
 
 if TYPE_CHECKING:
+    import cf_units
+
     from iris.common.mixin import CFVariableMixin
     from iris.coords import CellMethod
     from iris.util import Axis

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -31,7 +31,6 @@ import warnings
 from xml.dom.minidom import Document
 
 from cf_units import Unit
-import dask.array as da
 import numpy as np
 import numpy.ma as ma
 from packaging.version import Version
@@ -45,7 +44,6 @@ from iris.analysis import _Weights
 from iris.analysis.cartography import wrap_lons
 import iris.analysis.maths
 import iris.aux_factory
-from iris.aux_factory import AuxCoordFactory
 from iris.common import CFVariableMixin, CubeMetadata, metadata_manager_factory
 from iris.common.metadata import BaseMetadata, CoordMetadata, metadata_filter
 from iris.common.mixin import LimitedAttributeDict
@@ -61,10 +59,10 @@ from iris.coords import (
 )
 
 if TYPE_CHECKING:
-    from typing import TYPE_CHECKING
-
+    import dask.array as da
     from numpy.typing import ArrayLike
 
+    from iris.aux_factory import AuxCoordFactory
     import iris.mesh
     from iris.mesh import MeshCoord
 import iris.exceptions

--- a/lib/iris/fileformats/netcdf/saver.py
+++ b/lib/iris/fileformats/netcdf/saver.py
@@ -66,7 +66,12 @@ import iris.warnings
 
 if TYPE_CHECKING:
     from iris.cube import Cube
-    from iris.mesh.components import MeshXY
+    from iris.mesh.components import (
+        MeshEdgeCoords,
+        MeshFaceCoords,
+        MeshNodeCoords,
+        MeshXY,
+    )
 # Get the logger : shared logger for all in 'iris.fileformats.netcdf'.
 from . import logger
 
@@ -990,13 +995,6 @@ class Saver:
             NetCDF data compression keyword arguments.
 
         """
-        from iris.mesh.components import (
-            MeshEdgeCoords,
-            MeshFaceCoords,
-            MeshNodeCoords,
-            MeshXY,
-        )
-
         # Exclude any mesh coords, which are bundled in with the aux-coords.
         coords_to_add = [
             coord for coord in cube.aux_coords if not hasattr(coord, "mesh")

--- a/lib/iris/mesh/utils.py
+++ b/lib/iris/mesh/utils.py
@@ -12,13 +12,15 @@
 """
 
 from collections.abc import Sequence
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 import dask.array as da
 import numpy as np
 
-from iris.common.metadata import CoordMetadata
 from iris.cube import Cube
+
+if TYPE_CHECKING:
+    from iris.common.metadata import CoordMetadata
 
 
 def recombine_submeshes(

--- a/lib/iris/tests/stock/__init__.py
+++ b/lib/iris/tests/stock/__init__.py
@@ -8,9 +8,8 @@ import iris.tests as tests  # isort:skip
 
 from datetime import datetime
 from pathlib import Path
-from typing import NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
 
-from cartopy.crs import CRS
 from cf_units import Unit
 import numpy as np
 import numpy.ma as ma
@@ -29,6 +28,9 @@ from ._stock_2d_latlons import (  # noqa
     make_bounds_discontiguous_at_point,
     sample_2d_latlons,
 )
+
+if TYPE_CHECKING:
+    from cartopy.crs import CRS
 
 
 def lat_lon_cube():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -329,10 +329,6 @@ ignore = [
     # https://docs.astral.sh/ruff/rules/#flake8-tidy-imports-tid
     "TID",
 
-    # flake8-type-checking (TCH)
-    # https://docs.astral.sh/ruff/rules/#flake8-type-checking-tch
-    "TCH",
-
     # flake8-unused-arguments (ARG)
     # https://docs.astral.sh/ruff/rules/#flake8-unused-arguments-arg
     "ARG",


### PR DESCRIPTION
## Description

Enable the ruff [type checking](https://docs.astral.sh/ruff/rules/#flake8-type-checking-tc) rules. These rules are convenient because they allow automatically formatting the imports in such a way that circular dependencies from adding type hints are avoided.

#5625

## Checklist

> [!IMPORTANT]
> **The Iris core developers are here to help!** If anything below is unclear, just post a comment asking for help 😊

- [x] Included a [**What's New**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/documenting/whats_new_contributions.html) entry
- [x] Incorporated [**type hints**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_code_formatting.html#type-hinting) in any changed code
- [x] Checked if [**tests**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_tests.html) need updating
- [x] Checked if [**benchmarks**](../benchmarks/README.md#writing-benchmarks) need updating
- [x] Checked if **documentation** needs updating
  - [Docstrings](https://scitools-iris.readthedocs.io/en/latest/developers_guide/documenting/docstrings.html) (we love code examples!)
  - [User Manual](https://scitools-iris.readthedocs.io/en/latest/user_manual/) pages
- [x] Checked if [**dependencies**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_ci_tests.html#gha-test-env) need updating
- [x] Confirmed that the GitHub **'checks'** on this PR are passing :white_check_mark:
  _([further reading](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_ci_tests.html))_

---
> [!TIP]
> Things you can trigger on this PR:
>
> - Add this label to trigger benchmarks: https://github.com/SciTools/iris/labels/benchmark_this
> - Visit this URL - swapping `9999` for this PR's number - to re-trigger the [CLA check](https://github.com/SciTools/.github/wiki/Contributor-Licence-Agreement):
>   `https://cla-assistant.io/check/SciTools/iris?pullRequest=9999`
