### PR TITLE
Fix the pre-commit numpy doc failures

### DIFF
--- a/lib/iris/_combine.py
+++ b/lib/iris/_combine.py
@@ -252,8 +252,8 @@ class CombineOptions(threading.local):
         * kwargs : dict
             Individual option settings, from :data:`~iris.LoadPolicy.OPTION_KEYS`.
 
-        Note
-        ----
+        Notes
+        -----
         Keyword arguments are applied after the 'options' arg, and
         so will take precedence.
 

--- a/lib/iris/_constraints.py
+++ b/lib/iris/_constraints.py
@@ -615,16 +615,16 @@ class NameConstraint(Constraint):
             A string or callable representing the UM STASH code to match
             against.
 
+        Returns
+        -------
+        bool
+
         Notes
         -----
         The default value of each of the keyword arguments is the string
         "none", rather than the singleton None, as None may be a legitimate
         value to be matched against e.g., to constrain against all cubes
         where the standard_name is not set, then use standard_name=None.
-
-        Returns
-        -------
-        bool
 
         Examples
         --------

--- a/lib/iris/_shapefiles.py
+++ b/lib/iris/_shapefiles.py
@@ -91,6 +91,20 @@ def create_shape_mask(
         If the geometry CRS does not match the cube CRS, and the geometry is transformed
         to the cube CRS using pyproj.
 
+    Warnings
+    --------
+    Because shape vectors are inherently Cartesian in nature, they contain no inherent
+    understanding of the spherical geometry underpinning geographic coordinate systems.
+    For this reason, **shapefiles or shape vectors that cross the antimeridian or poles
+    are not supported by this function** to avoid unexpected masking behaviour.
+
+    Shape geometries can be checked prior to masking using the :func:`is_geometry_valid`.
+
+    See Also
+    --------
+    :func:`is_geometry_valid`
+        Check the validity of a shape geometry.
+
     Notes
     -----
     For best masking results, both the :class:`iris.cube.Cube` _and_ masking geometry should have a
@@ -110,19 +124,6 @@ def create_shape_mask(
     a `minimum_weight` > 0 *and* `all_touched` is set to `True`. This is because
     `all_touched=True` is equivalent to `minimum_weight=0`.
 
-    Warnings
-    --------
-    Because shape vectors are inherently Cartesian in nature, they contain no inherent
-    understanding of the spherical geometry underpinning geographic coordinate systems.
-    For this reason, **shapefiles or shape vectors that cross the antimeridian or poles
-    are not supported by this function** to avoid unexpected masking behaviour.
-
-    Shape geometries can be checked prior to masking using the :func:`is_geometry_valid`.
-
-    See Also
-    --------
-    :func:`is_geometry_valid`
-        Check the validity of a shape geometry.
     """
     # Check cube is a Cube
     if not isinstance(cube, iris.cube.Cube):  # type: ignore[unreachable]
@@ -458,16 +459,16 @@ def _make_raster_cube_transform(
 ) -> Affine:
     """Create a rasterio transform for the cube.
 
+    Returns
+    -------
+    :class:`affine.Affine`
+        An affine transform object that maps the geometry domain onto the cube domain.
+
     Raises
     ------
     CoordinateNotRegularError
         If the cube dimension coordinates are not regular,
         such that :func:`iris.util.regular_step` returns an error.
-
-    Returns
-    -------
-    :class:`affine.Affine`
-        An affine transform object that maps the geometry domain onto the cube domain.
     """
     x_points = x_coord.points
     y_points = y_coord.points

--- a/lib/iris/analysis/_scipy_interpolate.py
+++ b/lib/iris/analysis/_scipy_interpolate.py
@@ -176,8 +176,8 @@ class _RegularGridInterpolator:
         should only be used for passing to
         :meth:`interp_using_pre_computed_weights`.
 
-        Example
-        -------
+        Examples
+        --------
         >>> coords = np.array([[[50.7, -3.5],
                                 [50.6, -3.5]],
                                [[50.7, -3.1],

--- a/lib/iris/analysis/calculus.py
+++ b/lib/iris/analysis/calculus.py
@@ -149,12 +149,6 @@ def cube_delta(cube, coord):
         If a Coord instance is provided, it does not necessarily have to
         exist in the cube.
 
-    Examples
-    --------
-    ::
-
-        change_in_temperature_wrt_pressure = cube_delta(temperature_cube, 'pressure')
-
     Notes
     -----
     .. note:: Missing data support not yet implemented.
@@ -169,6 +163,12 @@ def cube_delta(cube, coord):
         be removed in ``Iris`` 4.0.0. Native :class:`~iris.cube.Cube` calculus
         will no longer be supported. Subsequently, :mod:`iris.analysis.calculus`
         is deprecated and will be removed in ``Iris`` 4.0.0.
+
+    Examples
+    --------
+    ::
+
+        change_in_temperature_wrt_pressure = cube_delta(temperature_cube, 'pressure')
 
     """
     wmsg = (

--- a/lib/iris/analysis/cartography.py
+++ b/lib/iris/analysis/cartography.py
@@ -67,6 +67,11 @@ def wrap_lons(lons, base, period):
     base :
     period :
 
+    Notes
+    -----
+    This function maintains laziness when called; it does not realise data.
+    See more at :doc:`/user_manual/explanation/real_and_lazy_data`.
+
     Examples
     --------
     .. testsetup::
@@ -79,10 +84,6 @@ def wrap_lons(lons, base, period):
         >>> print(wrap_lons(np.array([185, 30, -200, 75]), -180, 360))
         [-175.   30.  160.   75.]
 
-    Notes
-    -----
-    This function maintains laziness when called; it does not realise data.
-    See more at :doc:`/user_manual/explanation/real_and_lazy_data`.
     """
     # It is important to use 64bit floating precision when changing a floats
     # numbers range, but the original floating-point dtype is preserved so that
@@ -283,16 +284,16 @@ def get_xy_grids(cube):
     cube :
         The cube for which to generate 2D X and Y points.
 
+    Notes
+    -----
+    This function maintains laziness when called; it does not realise data.
+    See more at :doc:`/user_manual/explanation/real_and_lazy_data`.
+
     Examples
     --------
     ::
 
         x, y = get_xy_grids(cube)
-
-    Notes
-    -----
-    This function maintains laziness when called; it does not realise data.
-    See more at :doc:`/user_manual/explanation/real_and_lazy_data`.
 
     """
     x_coord, y_coord = cube.coord(axis="X"), cube.coord(axis="Y")
@@ -321,16 +322,16 @@ def get_xy_contiguous_bounded_grids(cube):
     ----------
     cube : :class:`iris.cube.Cube`
 
+    Notes
+    -----
+    This function maintains laziness when called; it does not realise data.
+    See more at :doc:`/user_manual/explanation/real_and_lazy_data`.
+
     Examples
     --------
     ::
 
         xs, ys = get_xy_contiguous_bounded_grids(cube)
-
-    Notes
-    -----
-    This function maintains laziness when called; it does not realise data.
-    See more at :doc:`/user_manual/explanation/real_and_lazy_data`.
 
     """
     x_coord, y_coord = cube.coord(axis="X"), cube.coord(axis="Y")
@@ -549,6 +550,11 @@ def cosine_latitude_weights(cube):
     ----------
     cube : :class:`iris.cube.Cube`
 
+    Notes
+    -----
+    This function maintains laziness when called; it does not realise data.
+    See more at :doc:`/user_manual/explanation/real_and_lazy_data`.
+
     Examples
     --------
     Compute weights suitable for averaging type operations::
@@ -565,10 +571,6 @@ def cosine_latitude_weights(cube):
         cube = iris.load_cube(iris.sample_data_path('air_temp.pp'))
         weights = np.sqrt(cosine_latitude_weights(cube))
 
-    Notes
-    -----
-    This function maintains laziness when called; it does not realise data.
-    See more at :doc:`/user_manual/explanation/real_and_lazy_data`.
     """
     # Find all latitude coordinates, we want one and only one.
     lat_coords = [coord for coord in cube.coords() if "latitude" in coord.name()]

--- a/lib/iris/analysis/trajectory.py
+++ b/lib/iris/analysis/trajectory.py
@@ -202,6 +202,11 @@ def interpolate(cube, sample_points, method=None):
         Only nearest neighbour is available when specifying multi-dimensional
         coordinates.
 
+    Notes
+    -----
+    This function does not maintain laziness when called; it realises data.
+    See more at :doc:`/user_manual/explanation/real_and_lazy_data`.
+
     Examples
     --------
     ::
@@ -210,10 +215,6 @@ def interpolate(cube, sample_points, method=None):
         ('longitude', [-60, -50, -40])]
         interpolated_cube = interpolate(cube, sample_points)
 
-    Notes
-    -----
-    This function does not maintain laziness when called; it realises data.
-    See more at :doc:`/user_manual/explanation/real_and_lazy_data`.
     """
     from iris.analysis import Linear
 

--- a/lib/iris/coord_systems.py
+++ b/lib/iris/coord_systems.py
@@ -337,8 +337,8 @@ class GeogCS(CoordSystem):
     def _globe(self):
         """A representation of this CRS as a Cartopy Globe.
 
-        Note
-        ----
+        Notes
+        -----
         This property is created when required and then cached for speed. That
         cached value is cleared when an assignment is made to a property of the
         class that invalidates the cache.
@@ -359,8 +359,8 @@ class GeogCS(CoordSystem):
     def _crs(self):
         """A representation of this CRS as a Cartopy CRS.
 
-        Note
-        ----
+        Notes
+        -----
         This property is created when required and then cached for speed. That
         cached value is cleared when an assignment is made to a property of the
         class that invalidates the cache.

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1905,16 +1905,16 @@ class Cube(CFVariableMixin):
             * (b) a cell_measure instance with metadata equal to that of
               the desired cell_measures.
 
+        See Also
+        --------
+        add_cell_measure :
+            Add a CF cell measure to the cube.
+
         Notes
         -----
         If the argument given does not represent a valid cell_measure on
         the cube, an :class:`iris.exceptions.CellMeasureNotFoundError`
         is raised.
-
-        See Also
-        --------
-        add_cell_measure :
-            Add a CF cell measure to the cube.
 
         """
         cell_measure = self.cell_measure(cell_measure)
@@ -2418,17 +2418,17 @@ class Cube(CFVariableMixin):
         -------
         The coordinate that matches the provided criteria.
 
+        See Also
+        --------
+        coords :
+            For matching zero or more coordinates.
+
         Notes
         -----
          .. note::
 
             If the arguments given do not result in **precisely one** coordinate,
             then a :class:`~iris.exceptions.CoordinateNotFoundError` is raised.
-
-        See Also
-        --------
-        coords :
-            For matching zero or more coordinates.
 
         """
         coords = self.coords(
@@ -2680,14 +2680,6 @@ class Cube(CFVariableMixin):
     ) -> CellMeasure:
         """Return a single cell_measure given the same arguments as :meth:`Cube.cell_measures`.
 
-        Notes
-        -----
-        .. note::
-
-            If the arguments given do not result in precisely 1 cell_measure
-            being matched, an :class:`iris.exceptions.CellMeasureNotFoundError`
-            is raised.
-
         Returns
         -------
         CellMeasure
@@ -2697,6 +2689,14 @@ class Cube(CFVariableMixin):
         --------
         cell_measures :
             For full keyword documentation.
+
+        Notes
+        -----
+        .. note::
+
+            If the arguments given do not result in precisely 1 cell_measure
+            being matched, an :class:`iris.exceptions.CellMeasureNotFoundError`
+            is raised.
 
         """
         cell_measures = self.cell_measures(name_or_cell_measure)
@@ -2782,14 +2782,6 @@ class Cube(CFVariableMixin):
     ) -> AncillaryVariable:
         """Return a single ancillary_variable given the same arguments as :meth:`Cube.ancillary_variables`.
 
-        Notes
-        -----
-        .. note::
-
-            If the arguments given do not result in precisely 1
-            ancillary_variable being matched, an
-            :class:`iris.exceptions.AncillaryVariableNotFoundError` is raised.
-
         Returns
         -------
         AncillaryVariable
@@ -2799,6 +2791,14 @@ class Cube(CFVariableMixin):
         --------
         ancillary_variables :
             For full keyword documentation.
+
+        Notes
+        -----
+        .. note::
+
+            If the arguments given do not result in precisely 1
+            ancillary_variable being matched, an
+            :class:`iris.exceptions.AncillaryVariableNotFoundError` is raised.
 
         """
         ancillary_variables = self.ancillary_variables(name_or_ancillary_variable)
@@ -3465,15 +3465,11 @@ class Cube(CFVariableMixin):
             Minimum proportion of a bounded cell that must overlap with the
             specified range. Default 0.
 
-        Notes
-        -----
-        .. note::
-
-            For ranges defined over "circular" coordinates (i.e. those
-            where the `units` attribute has a modulus defined) the cube
-            will be "rolled" to fit where necessary.  When requesting a
-            range that covers the entire modulus, a split cell will
-            preferentially be placed at the ``minimum`` end.
+        Returns
+        -------
+        :class:`~iris.cube.Cube`
+            A new :class:`~iris.cube.Cube` giving the subset of the cube
+            which intersects with the requested coordinate intervals.
 
         Warnings
         --------
@@ -3496,11 +3492,15 @@ class Cube(CFVariableMixin):
             >>> print(subset.coord('longitude').points)
             [-7.50012207 -3.75012207  0.          3.75        7.5       ]
 
-        Returns
-        -------
-        :class:`~iris.cube.Cube`
-            A new :class:`~iris.cube.Cube` giving the subset of the cube
-            which intersects with the requested coordinate intervals.
+        Notes
+        -----
+        .. note::
+
+            For ranges defined over "circular" coordinates (i.e. those
+            where the `units` attribute has a modulus defined) the cube
+            will be "rolled" to fit where necessary.  When requesting a
+            range that covers the entire modulus, a split cell will
+            preferentially be placed at the ``minimum`` end.
 
         """
         result = self
@@ -3883,6 +3883,19 @@ class Cube(CFVariableMixin):
         -------
         An iterator of subcubes.
 
+        See Also
+        --------
+        iris.cube.Cube.slices :
+            Return an iterator of all subcubes given the coordinates or dimension indices.
+
+        Notes
+        -----
+        .. note::
+
+            The order of dimension references to slice along does not affect
+            the order of returned items in the iterator; instead the ordering
+            is based on the fastest-changing dimension.
+
         Examples
         --------
         For example, for a cube with dimensions `realization`, `time`, `latitude` and
@@ -3916,19 +3929,6 @@ class Cube(CFVariableMixin):
         ...     print(sub_cube.summary(shorten=True))
         surface_temperature / (K)           (time: 6; latitude: 145; longitude: 192)
         surface_temperature / (K)           (time: 6; latitude: 145; longitude: 192)
-
-        Notes
-        -----
-        .. note::
-
-            The order of dimension references to slice along does not affect
-            the order of returned items in the iterator; instead the ordering
-            is based on the fastest-changing dimension.
-
-        See Also
-        --------
-        iris.cube.Cube.slices :
-            Return an iterator of all subcubes given the coordinates or dimension indices.
 
         """  # noqa: D214, D406, D407, D410, D411
         # Required to handle a mix between types.
@@ -3988,6 +3988,12 @@ class Cube(CFVariableMixin):
         -------
         An iterator of subcubes.
 
+        See Also
+        --------
+        iris.cube.Cube.slices_over :
+            Return an iterator of all subcubes along a given coordinate or
+            dimension index.
+
         Examples
         --------
         For example, for a cube with dimensions `realization`, `time`, `latitude` and
@@ -4027,12 +4033,6 @@ class Cube(CFVariableMixin):
         ...     print(sub_cube.summary(shorten=True))
         surface_temperature / (K)           (time: 6; latitude: 145; longitude: 192)
         surface_temperature / (K)           (time: 6; latitude: 145; longitude: 192)
-
-        See Also
-        --------
-        iris.cube.Cube.slices_over :
-            Return an iterator of all subcubes along a given coordinate or
-            dimension index.
 
         """  # noqa: D214, D406, D407, D410, D411
         if not isinstance(ordered, bool):
@@ -4611,31 +4611,6 @@ class Cube(CFVariableMixin):
         -------
         Collapsed cube.
 
-        Examples
-        --------
-            >>> import iris
-            >>> import iris.analysis
-            >>> path = iris.sample_data_path('ostia_monthly.nc')
-            >>> cube = iris.load_cube(path)
-            >>> new_cube = cube.collapsed('longitude', iris.analysis.MEAN)
-            >>> print(new_cube)
-            surface_temperature / (K)           (time: 54; latitude: 18)
-                Dimension coordinates:
-                    time                             x             -
-                    latitude                         -             x
-                Auxiliary coordinates:
-                    forecast_reference_time          x             -
-                Scalar coordinates:
-                    forecast_period             0 hours
-                    longitude                   \
-180.0 degrees, bound=(0.0, 360.0) degrees
-                Cell methods:
-                    0                           month: year: mean
-                    1                           longitude: mean
-                Attributes:
-                    Conventions                 'CF-1.5'
-                    STASH                       m01s00i024
-
         Notes
         -----
         .. note::
@@ -4664,6 +4639,32 @@ class Cube(CFVariableMixin):
 
                 cube.collapsed(['latitude', 'longitude'],
                                iris.analysis.VARIANCE)
+
+        Examples
+        --------
+            >>> import iris
+            >>> import iris.analysis
+            >>> path = iris.sample_data_path('ostia_monthly.nc')
+            >>> cube = iris.load_cube(path)
+            >>> new_cube = cube.collapsed('longitude', iris.analysis.MEAN)
+            >>> print(new_cube)
+            surface_temperature / (K)           (time: 54; latitude: 18)
+                Dimension coordinates:
+                    time                             x             -
+                    latitude                         -             x
+                Auxiliary coordinates:
+                    forecast_reference_time          x             -
+                Scalar coordinates:
+                    forecast_period             0 hours
+                    longitude                   \
+180.0 degrees, bound=(0.0, 360.0) degrees
+                Cell methods:
+                    0                           month: year: mean
+                    1                           longitude: mean
+                Attributes:
+                    Conventions                 'CF-1.5'
+                    STASH                       m01s00i024
+
         """
         # Update weights kwargs (if necessary) to handle different types of
         # weights

--- a/lib/iris/experimental/regrid.py
+++ b/lib/iris/experimental/regrid.py
@@ -154,11 +154,6 @@ def regrid_weighted_curvilinear_to_rectilinear(src_cube, weights, grid_cube):
     :math:`\sum (src\_cube.data_{ij} * weights_{ij}) / \sum weights_{ij}`, for
     all :math:`ij` :data:`src_cube` points that are bound by that cell.
 
-    Warnings
-    --------
-    All coordinates that span the :data:`src_cube` that don't define
-    the horizontal curvilinear grid will be ignored.
-
     Parameters
     ----------
     src_cube : :class:`iris.cube.Cube`
@@ -175,6 +170,11 @@ def regrid_weighted_curvilinear_to_rectilinear(src_cube, weights, grid_cube):
     Returns
     -------
     A :class:`iris.cube.Cube` instance.
+
+    Warnings
+    --------
+    All coordinates that span the :data:`src_cube` that don't define
+    the horizontal curvilinear grid will be ignored.
 
     Notes
     -----

--- a/lib/iris/fileformats/netcdf/saver.py
+++ b/lib/iris/fileformats/netcdf/saver.py
@@ -363,8 +363,8 @@ class Saver:
         -------
         None
 
-        Example
-        -------
+        Examples
+        --------
         >>> import iris
         >>> from iris.fileformats.netcdf.saver import Saver
         >>> cubes = iris.load(iris.sample_data_path('atlantic_profiles.nc'))
@@ -2422,14 +2422,14 @@ class Saver:
         fill_value : optional
             See :func:`iris.fileformats.netcdf.Saver.write`.
 
+        Returns
+        -------
+        The newly created CF-netCDF data variable.
+
         Notes
         -----
         All other keywords are passed through to the dataset's `createVariable`
         method.
-
-        Returns
-        -------
-        The newly created CF-netCDF data variable.
 
         """
         # TODO: when iris.FUTURE.save_split_attrs is removed, the 'local_keys' arg can

--- a/lib/iris/io/__init__.py
+++ b/lib/iris/io/__init__.py
@@ -470,6 +470,11 @@ def save(source, target, saver=None, **kwargs):
     data can result in corruption. Users should proceed with caution when
     attempting to overwrite an existing file.
 
+    Notes
+    -----
+    This function maintains laziness when called; it does not realise data.
+    See more at :doc:`/user_manual/explanation/real_and_lazy_data`.
+
     Examples
     --------
     >>> # Setting up
@@ -489,11 +494,6 @@ def save(source, target, saver=None, **kwargs):
 
     >>> # Save a cube list to netCDF, using the NETCDF3_CLASSIC storage option
     >>> iris.save(my_cube_list, "myfile.nc", netcdf_format="NETCDF3_CLASSIC")
-
-    Notes
-    -----
-    This function maintains laziness when called; it does not realise data.
-    See more at :doc:`/user_manual/explanation/real_and_lazy_data`.
 
     """
     from iris.cube import Cube, CubeList

--- a/lib/iris/iterate.py
+++ b/lib/iris/iterate.py
@@ -49,6 +49,11 @@ def izip(*cubes, **kwargs):
     -------
     An iterator over a collection of tuples that contain the resulting subcubes.
 
+    Notes
+    -----
+    This function maintains laziness when called; it does not realise data.
+    See more at :doc:`/user_manual/explanation/real_and_lazy_data`.
+
     Examples
     --------
         >>> e_content, e_density = iris.load_cubes(
@@ -58,11 +63,6 @@ def izip(*cubes, **kwargs):
         ...                                         coords=['grid_latitude',
         ...                                                 'grid_longitude']):
         ...    pass
-
-    Notes
-    -----
-    This function maintains laziness when called; it does not realise data.
-    See more at :doc:`/user_manual/explanation/real_and_lazy_data`.
 
     """
     if not cubes:

--- a/lib/iris/loading.py
+++ b/lib/iris/loading.py
@@ -53,8 +53,8 @@ class _LazyDerivedLoading(threading.local):
         load_lazy : bool, default False
             Sets whether references are loaded as lazy data, within the context.
 
-        Example
-        -------
+        Examples
+        --------
         >>> with _LAZY_DERIVED_LOADING.context(load_lazy=True):
         ...     <code>
         """

--- a/lib/iris/plot.py
+++ b/lib/iris/plot.py
@@ -1891,6 +1891,11 @@ def animate(cube_iterator, plot_func, fig=None, **kwargs):
     -------
     :class:`~matplotlib.animation.FuncAnimation` object suitable for saving and or plotting.
 
+    Notes
+    -----
+    This function does not maintain laziness when called; it realises data.
+    See more at :doc:`/user_manual/explanation/real_and_lazy_data`.
+
     Examples
     --------
     >>> import iris
@@ -1903,11 +1908,6 @@ def animate(cube_iterator, plot_func, fig=None, **kwargs):
     >>> cube_iter = my_cube.slices(("longitude", "latitude"))
     >>> ani = iplt.animate(cube_iter, qplt.contourf)
     >>> iplt.show()
-
-    Notes
-    -----
-    This function does not maintain laziness when called; it realises data.
-    See more at :doc:`/user_manual/explanation/real_and_lazy_data`.
 
     """
     kwargs.setdefault("interval", 100)

--- a/lib/iris/quickplot.py
+++ b/lib/iris/quickplot.py
@@ -223,12 +223,13 @@ def contourf(cube, *args, **kwargs):
 
         contour(cube, V)
 
-    Keywords
-    --------
-    colorbar : bool, default=True
-        If True, an appropriate colorbar will be added to the plot.
+    Parameters
+    ----------
+    colorbar : bool, optional
+        If True, an appropriate colorbar will be added to the plot. Defaults to True.
 
-    See :func:`iris.plot.contourf` for details of valid keyword arguments.
+    **kwargs : dict, optional
+        See :func:`iris.plot.contourf` for details of other valid keyword arguments.
 
     Notes
     -----
@@ -280,17 +281,19 @@ def outline(cube, coords=None, color="k", linewidth=None, axes=None, footer=None
 def pcolor(cube, *args, **kwargs):
     """Draw a labelled pseudocolor plot based on the given Cube.
 
-    Keywords
-    --------
-    colorbar : bool, default=True
-        If True, an appropriate colorbar will be added to the plot.
+    Parameters
+    ----------
+    colorbar : bool, optional
+        If True, an appropriate colorbar will be added to the plot. Defaults to True.
 
-    See :func:`iris.plot.pcolor` for details of valid keyword arguments.
+    **kwargs : dict, optional
+        See :func:`iris.plot.pcolor` for details of other valid keyword arguments.
 
     Notes
     -----
     This function does not maintain laziness when called; it realises data.
     See more at :doc:`/user_manual/explanation/real_and_lazy_data`.
+
     """
     coords = kwargs.get("coords")
     axes = kwargs.get("axes")
@@ -305,12 +308,13 @@ def pcolor(cube, *args, **kwargs):
 def pcolormesh(cube, *args, **kwargs):
     """Draw a labelled pseudocolour plot based on the given Cube.
 
-    Keywords
-    --------
-    colorbar : bool, default=True
-        If True, an appropriate colorbar will be added to the plot.
+    Parameters
+    ----------
+    colorbar : bool, optional
+        If True, an appropriate colorbar will be added to the plot. Defaults to True.
 
-    See :func:`iris.plot.pcolormesh` for details of valid keyword arguments.
+    **kwargs : dict, optional
+        See :func:`iris.plot.pcolormesh` for details of other valid keyword arguments.
 
     Notes
     -----

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -2413,6 +2413,11 @@ def mask_cube_from_shape(
     of Iris, using tools like `GDAL <https://gdal.org/en/stable/programs/ogr2ogr.html>`_ or
     `antimeridian <https://github.com/gadomski/antimeridian>`_ to fix shape wrapping.
 
+    See Also
+    --------
+    :func:`~iris.util.mask_cube`
+        Mask any cells in the cube’s data array.
+
     Notes
     -----
     Iris does not handle the shape loading so it is agnostic to the source type of the shape.
@@ -2420,11 +2425,6 @@ def mask_cube_from_shape(
     `shapely <https://shapely.readthedocs.io/en/stable/>`_ library, or any other source that
     can be interpreted as a `shapely.Geometry <https://shapely.readthedocs.io/en/stable/geometry.html>`_
     object, such as shapes encoded in a geoJSON or KML file.
-
-    See Also
-    --------
-    :func:`~iris.util.mask_cube`
-        Mask any cells in the cube’s data array.
 
     Examples
     --------

--- a/lib/iris/util.py
+++ b/lib/iris/util.py
@@ -80,6 +80,11 @@ def broadcast_to_shape(array, shape, dim_map, chunks=None):
         here will only be used along dimensions that are new on the result or
         have size 1 on the source array.
 
+    Notes
+    -----
+    This function maintains laziness when called; it does not realise data.
+    See more at :doc:`/user_manual/explanation/real_and_lazy_data`.
+
     Examples
     --------
     Broadcasting an array of shape (2, 3) to the shape (5, 2, 6, 3)
@@ -94,11 +99,6 @@ def broadcast_to_shape(array, shape, dim_map, chunks=None):
 
         # a is an array of shape (48, 96)
         result = broadcast_to_shape(a, (96, 48, 12), (1, 0))
-
-    Notes
-    -----
-    This function maintains laziness when called; it does not realise data.
-    See more at :doc:`/user_manual/explanation/real_and_lazy_data`.
 
     """
     if isinstance(array, da.Array):
@@ -220,6 +220,11 @@ def describe_diff(cube_a, cube_b, output_file=None):
         A :class:`file` or file-like object to receive output. Defaults to
         sys.stdout.
 
+    See Also
+    --------
+    iris.cube.Cube.is_compatible :
+        Check if a Cube is compatible with another.
+
     Notes
     -----
     This function maintains laziness when called; it does not realise data.
@@ -232,11 +237,6 @@ def describe_diff(cube_a, cube_b, output_file=None):
         of the differences in metadata between two cubes. Determining whether
         two cubes will merge requires additional logic that is beyond the
         scope of this function.
-
-    See Also
-    --------
-    iris.cube.Cube.is_compatible :
-        Check if a Cube is compatible with another.
 
     """
     if output_file is None:
@@ -359,6 +359,11 @@ def rolling_window(
         Array that is a view of the original array with an added dimension
         of the size of the given window at axis + 1.
 
+    Notes
+    -----
+    This function maintains laziness when called; it does not realise data.
+    See more at :doc:`/user_manual/explanation/real_and_lazy_data`.
+
     Examples
     --------
     ::
@@ -373,11 +378,6 @@ def rolling_window(
         >>> np.mean(rolling_window(x, 3), -1)
         array([[ 1.,  2.,  3.],
                [ 6.,  7.,  8.]])
-
-    Notes
-    -----
-    This function maintains laziness when called; it does not realise data.
-    See more at :doc:`/user_manual/explanation/real_and_lazy_data`.
 
     """
     if window < 1:
@@ -590,6 +590,11 @@ def between(lh, rh, lh_inclusive=True, rh_inclusive=True):
     rh_inclusive : bool, default=True
         Same as lh_inclusive but for right hand operator.
 
+    Notes
+    -----
+    This function does maintain laziness when called; it doesn't realise data.
+    See more at :doc:`/user_manual/explanation/real_and_lazy_data`.
+
     Examples
     --------
     ::
@@ -602,11 +607,6 @@ def between(lh, rh, lh_inclusive=True, rh_inclusive=True):
         between_3_and_6 = between(3, 6, rh_inclusive=False)
         for i in range(10):
            print(i, between_3_and_6(i))
-
-    Notes
-    -----
-    This function does maintain laziness when called; it doesn't realise data.
-    See more at :doc:`/user_manual/explanation/real_and_lazy_data`.
 
     """
     if lh_inclusive and rh_inclusive:
@@ -631,6 +631,11 @@ def reverse(cube_or_array, coords_or_dims):
         numpy array, use int or a sequence of ints, as in the examples below.
         If cube_or_array is a Cube, a Coord or coordinate name (or sequence of
         these) may be specified instead.
+
+    Notes
+    -----
+    This function maintains laziness when called; it does not realise data.
+    See more at :doc:`/user_manual/explanation/real_and_lazy_data`.
 
     Examples
     --------
@@ -662,11 +667,6 @@ def reverse(cube_or_array, coords_or_dims):
          [[23 22 21 20]
           [19 18 17 16]
           [15 14 13 12]]]
-
-    Notes
-    -----
-    This function maintains laziness when called; it does not realise data.
-    See more at :doc:`/user_manual/explanation/real_and_lazy_data`.
 
     """
     from iris.cube import Cube
@@ -1275,6 +1275,11 @@ def new_axis(src_cube, scalar_coord=None, expand_extras=()):  # maybe not lazy
         variables will also be given an additional dimension, associated with
         the leading dimension of the cube.
 
+    Notes
+    -----
+    This function does maintain laziness when called; it doesn't realise data.
+    See more at :doc:`/user_manual/explanation/real_and_lazy_data`.
+
     Examples
     --------
     ::
@@ -1284,11 +1289,6 @@ def new_axis(src_cube, scalar_coord=None, expand_extras=()):  # maybe not lazy
         >>> ncube = iris.util.new_axis(cube, 'time')
         >>> ncube.shape
         (1, 360, 360)
-
-    Notes
-    -----
-    This function does maintain laziness when called; it doesn't realise data.
-    See more at :doc:`/user_manual/explanation/real_and_lazy_data`.
 
     """
 
@@ -1394,6 +1394,11 @@ def squeeze(cube):
         A new :class:`iris.cube.Cube` instance without any dimensions of
         length 1.
 
+    Notes
+    -----
+    This function maintains laziness when called; it does not realise data.
+    See more at :doc:`/user_manual/explanation/real_and_lazy_data`.
+
     Examples
     --------
     For example::
@@ -1403,11 +1408,6 @@ def squeeze(cube):
         >>> ncube = iris.util.squeeze(cube)
         >>> ncube.shape
         (360, 360)
-
-    Notes
-    -----
-    This function maintains laziness when called; it does not realise data.
-    See more at :doc:`/user_manual/explanation/real_and_lazy_data`.
 
     """
     slices = [0 if cube.shape[dim] == 1 else slice(None) for dim in range(cube.ndim)]
@@ -1705,6 +1705,11 @@ def promote_aux_coord_to_dim_coord(cube, name_or_coord):
           :attr:`var_name` of an instance of an instance of
           :class:`iris.coords.AuxCoord`.
 
+    Notes
+    -----
+    This function maintains laziness when called; it does not realise data.
+    See more at :doc:`/user_manual/explanation/real_and_lazy_data`.
+
     Examples
     --------
     .. testsetup:: promote
@@ -1740,11 +1745,6 @@ def promote_aux_coord_to_dim_coord(cube, name_or_coord):
             Auxiliary coordinates:
                 forecast_period                  x              -              -
                 time                             x              -              -
-
-    Notes
-    -----
-    This function maintains laziness when called; it does not realise data.
-    See more at :doc:`/user_manual/explanation/real_and_lazy_data`.
 
     """
     from iris.coords import Coord, DimCoord
@@ -1824,6 +1824,11 @@ def demote_dim_coord_to_aux_coord(cube, name_or_coord):
           :attr:`var_name` of an instance of an instance of
           :class:`iris.coords.DimCoord`.
 
+    Notes
+    -----
+    This function maintains laziness when called; it does not realise data.
+    See more at :doc:`/user_manual/explanation/real_and_lazy_data`.
+
     Examples
     --------
     .. testsetup:: demote
@@ -1859,11 +1864,6 @@ def demote_dim_coord_to_aux_coord(cube, name_or_coord):
                 forecast_period                 x              -              -
                 time                            x              -              -
                 year                            x              -              -
-
-    Notes
-    -----
-    This function maintains laziness when called; it does not realise data.
-    See more at :doc:`/user_manual/explanation/real_and_lazy_data`.
 
     """
     from iris.coords import Coord
@@ -1939,6 +1939,11 @@ def find_discontiguities(cube, rel_tol=1e-5, abs_tol=1e-8):
         This can be used as the input array for
         :func:`iris.util.mask_cube`.
 
+    Notes
+    -----
+    This function does not maintain laziness when called; it realises data.
+    See more at :doc:`/user_manual/explanation/real_and_lazy_data`.
+
     Examples
     --------
     ::
@@ -1954,10 +1959,6 @@ def find_discontiguities(cube, rel_tol=1e-5, abs_tol=1e-8):
         # Plot the masked cube slice:
         iplt.pcolormesh(masked_cube_slice)
 
-    Notes
-    -----
-    This function does not maintain laziness when called; it realises data.
-    See more at :doc:`/user_manual/explanation/real_and_lazy_data`.
 
     """
     lats_and_lons = [
@@ -2286,6 +2287,12 @@ def mask_cube_from_shapefile(
     iris.Cube
         A masked version of the input cube, if in_place is False.
 
+    Warnings
+    --------
+    This function requires additional dependencies:
+    `rasterio <https://rasterio.readthedocs.io/en/stable/>`_
+    and `affine <https://affine.readthedocs.io/en/latest/>`_.
+
     See Also
     --------
     :func:`~iris.util.mask_cube`
@@ -2300,12 +2307,6 @@ def mask_cube_from_shapefile(
         :func:`mask_cube_from_shapefile` function is scheduled for removal in a
         future release, being replaced by :func:`iris.util.mask_cube_from_shape`,
         which offers richer shape handling.
-
-    Warnings
-    --------
-    This function requires additional dependencies:
-    `rasterio <https://rasterio.readthedocs.io/en/stable/>`_
-    and `affine <https://affine.readthedocs.io/en/latest/>`_.
     """
     message = (
         "iris.util.mask_cube_from_shapefile has been deprecated, and will be removed in a "
@@ -2390,6 +2391,36 @@ def mask_cube_from_shape(
     iris.Cube
         A masked version of the input cube, if ``in_place`` is ``False``.
 
+    Warnings
+    --------
+    For best masking results, both the cube **and** masking geometry should have a
+    coordinate reference system (CRS) defined. Note that CRS of the masking geometry
+    must be provided explicitly to this function (via ``shape_crs``), whereas the
+    cube CRS is read from the cube itself. The cube **must** have a coord_system defined.
+
+    Masking results will be most consistent when the cube and masking geometry have the same CRS.
+
+    If a CRS is **not** provided for the the masking geometry, the CRS of the cube is assumed.
+
+    This function requires additional dependencies: `rasterio <https://rasterio.readthedocs.io/en/stable/>`_
+    and `affine <https://affine.readthedocs.io/en/latest/>`_.
+
+    Because shape vectors are inherently Cartesian in nature, they contain no inherent
+    understanding of the spherical geometry underpinning geographic coordinate systems.
+    For this reason, **shapefiles or shape vectors that cross the antimeridian or poles
+    are not supported by this function** to avoid unexpected masking behaviour.  For shapes
+    that do cross these boundaries, this function expects the user to undertake fixes upstream
+    of Iris, using tools like `GDAL <https://gdal.org/en/stable/programs/ogr2ogr.html>`_ or
+    `antimeridian <https://github.com/gadomski/antimeridian>`_ to fix shape wrapping.
+
+    Notes
+    -----
+    Iris does not handle the shape loading so it is agnostic to the source type of the shape.
+    The shape can be loaded from an Esri shapefile, created using the
+    `shapely <https://shapely.readthedocs.io/en/stable/>`_ library, or any other source that
+    can be interpreted as a `shapely.Geometry <https://shapely.readthedocs.io/en/stable/geometry.html>`_
+    object, such as shapes encoded in a geoJSON or KML file.
+
     See Also
     --------
     :func:`~iris.util.mask_cube`
@@ -2446,36 +2477,6 @@ def mask_cube_from_shape(
     >>> shape = shapely.geometry.box(-100,30, -80,40) # box between 30N-40N 100W-80W
     >>> wgs84 = CRS.from_epsg(4326)
     >>> masked_cube = mask_cube_from_shape(cube, shape, wgs84)
-
-    Notes
-    -----
-    Iris does not handle the shape loading so it is agnostic to the source type of the shape.
-    The shape can be loaded from an Esri shapefile, created using the
-    `shapely <https://shapely.readthedocs.io/en/stable/>`_ library, or any other source that
-    can be interpreted as a `shapely.Geometry <https://shapely.readthedocs.io/en/stable/geometry.html>`_
-    object, such as shapes encoded in a geoJSON or KML file.
-
-    Warnings
-    --------
-    For best masking results, both the cube **and** masking geometry should have a
-    coordinate reference system (CRS) defined. Note that CRS of the masking geometry
-    must be provided explicitly to this function (via ``shape_crs``), whereas the
-    cube CRS is read from the cube itself. The cube **must** have a coord_system defined.
-
-    Masking results will be most consistent when the cube and masking geometry have the same CRS.
-
-    If a CRS is **not** provided for the the masking geometry, the CRS of the cube is assumed.
-
-    This function requires additional dependencies: `rasterio <https://rasterio.readthedocs.io/en/stable/>`_
-    and `affine <https://affine.readthedocs.io/en/latest/>`_.
-
-    Because shape vectors are inherently Cartesian in nature, they contain no inherent
-    understanding of the spherical geometry underpinning geographic coordinate systems.
-    For this reason, **shapefiles or shape vectors that cross the antimeridian or poles
-    are not supported by this function** to avoid unexpected masking behaviour.  For shapes
-    that do cross these boundaries, this function expects the user to undertake fixes upstream
-    of Iris, using tools like `GDAL <https://gdal.org/en/stable/programs/ogr2ogr.html>`_ or
-    `antimeridian <https://github.com/gadomski/antimeridian>`_ to fix shape wrapping.
 
     """
     from iris._shapefiles import create_shape_mask


### PR DESCRIPTION
## Description

Fixes numpy doc failures in #7127 

Mostly just reordering numpy doc headings. In some cases, it was merely a typo, and in one case I had to move the Keywords section into Parameters (with some refactoring based on online examples). 

## Checklist

> [!IMPORTANT]
> **The Iris core developers are here to help!** If anything below is unclear, just post a comment asking for help 😊

- [ ] Included a [**What's New**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/documenting/whats_new_contributions.html) entry
- [x] Incorporated [**type hints**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_code_formatting.html#type-hinting) in any changed code
- [x] Checked if [**tests**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_tests.html) need updating
- [x] Checked if [**benchmarks**](../benchmarks/README.md#writing-benchmarks) need updating
- [x] Checked if **documentation** needs updating
  - [Docstrings](https://scitools-iris.readthedocs.io/en/latest/developers_guide/documenting/docstrings.html) (we love code examples!)
  - [User Manual](https://scitools-iris.readthedocs.io/en/latest/user_manual/) pages
- [x] Checked if [**dependencies**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_ci_tests.html#gha-test-env) need updating
- [x] Confirmed that the GitHub **'checks'** on this PR are passing :white_check_mark:
  _([further reading](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_ci_tests.html))_

---
> [!TIP]
> Things you can trigger on this PR:
>
> - Add this label to trigger benchmarks: https://github.com/SciTools/iris/labels/benchmark_this
> - Visit this URL - swapping `9999` for this PR's number - to re-trigger the [CLA check](https://github.com/SciTools/.github/wiki/Contributor-Licence-Agreement):
>   `https://cla-assistant.io/check/SciTools/iris?pullRequest=9999`
