### PR TITLE
Support utf8 by default for saving strings.

### DIFF
--- a/docs/src/user_manual/explanation/netcdf_io.rst
+++ b/docs/src/user_manual/explanation/netcdf_io.rst
@@ -195,7 +195,7 @@ attribute will still be added to the Iris component object.
 
 When saving
 ~~~~~~~~~~~
-To save string data **does not require an ``_Encoding`` attribute**, since UTF-8 is
+To save string data **does not require** an ``_Encoding`` attribute, since UTF-8 is
 applied by default -- which, for ascii data, is also equivalent to ``"ascii"``.
 
 An ``_Encoding`` attribute can however be provided : either for clarity, or to specify a

--- a/docs/src/user_manual/explanation/netcdf_io.rst
+++ b/docs/src/user_manual/explanation/netcdf_io.rst
@@ -167,7 +167,7 @@ When strings may include non-ascii characters, this requires a specific encoding
 adopted when translating to and from bytes, and rules for determining what the encoding
 is or was.
 
-In some cases a definite record of the byte encoding is needed (though often a default
+In some cases a definite record of the byte encoding is needed (though usually a default
 can be assumed) : An encoding name can appear in the ``_Encoding`` attribute of a file
 variable, and likewise as an attribute of the corresponding Iris component object
 (e.g. cube or coordinate) :  This is loaded and saved as a normal attribute without
@@ -180,7 +180,7 @@ Iris supports only certain specific encodings :
 * "utf16"
 * "utf32"
 
-(Though, common aliases are also allowed, those recognised by the Python ``codecs``
+(Though, common aliases are also allowed : those recognised by the Python ``codecs``
 module).
 
 When loading
@@ -195,17 +195,26 @@ attribute will still be added to the Iris component object.
 
 When saving
 ~~~~~~~~~~~
-Any string data with only ascii characters does not require an ``_Encoding`` attribute.
+To save string data **does not require an ``_Encoding`` attribute**, since UTF-8 is
+applied by default -- which, for ascii data, is also equivalent to ``"ascii"``.
 
-However if there are any non-ascii characters, and no ``_Encoding``
-attribute, then an error will be raised.
-This can be fixed by adding a suitable ``_Encoding`` attribute, for example:
-``cube.attributes["_Encoding"] = "utf8"``.
+An ``_Encoding`` attribute can however be provided : either for clarity, or to specify a
+non-default encoding (e.g. UTF-32).  This will be saved to the file.
+
+If there are characters which can not be encoded then an error will be raised.
+At present, the only *supported* encoding which this applies to is ``"ascii"``, but in
+theory it could happen with other encodings, like "ISO-8859-1".
 
 An invalid or unsupported encoding name will be ignored, with a warning, but the
 attribute will still be stored to the file.
 
-So effectively, the **default encoding is 'utf8' for load and 'ascii' for save**.
+So effectively,
+
+*   the **default encoding is 'utf8'** for both load and for save
+*   no data ever actually **requires** an ``_Encoding`` to save correctly
+*   if there **is** an ``_Encoding`` attribute, saving checks the actual data for
+    compliance
+
 
 String widths and string dimensions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/iris/fileformats/netcdf/_bytecoding_datasets.py
+++ b/lib/iris/fileformats/netcdf/_bytecoding_datasets.py
@@ -233,7 +233,7 @@ class NetcdfStringDecodeSetting(threading.local):
 
 DECODE_TO_STRINGS_ON_READ = NetcdfStringDecodeSetting()
 DEFAULT_READ_ENCODING = "utf-8"
-DEFAULT_WRITE_ENCODING = "ascii"
+DEFAULT_WRITE_ENCODING = "utf-8"
 
 
 @dataclasses.dataclass

--- a/lib/iris/tests/integration/netcdf/test_stringdata.py
+++ b/lib/iris/tests/integration/netcdf/test_stringdata.py
@@ -205,6 +205,11 @@ def load_problems_list():
     return [str(prob) for prob in iris.loading.LOAD_PROBLEMS.problems]
 
 
+@pytest.fixture(autouse=True)
+def tmp_path():
+    return Path("/home/users/patrick.peglar/chararray_testfiles")
+
+
 class TestReadEncodings:
     """Test loading of testfiles with encoded string data."""
 
@@ -632,15 +637,17 @@ class TestReadParticularCases:
 
 
 class TestWriteParticularCases:
-    def test_write_unicode_no_encoding__fail(self, tmp_path):
-        cube = Cube(np.array("éclair"))
+    def test_write_unicode_no_encoding(self, tmp_path):
+        cube = Cube(np.array(["bun", "éclair"], dtype="U10"))
         filepath = tmp_path / "write_unicode_no_encoding.nc"
-        msg = (
-            "String data written to netcdf character variable 'unknown' "
-            "could not be represented in encoding 'ascii'"
-        )
-        with pytest.raises(ValueError, match=msg):
-            iris.save(cube, filepath)
+        # This now "just works", since default is UTF-8
+        iris.save(cube, filepath)
+        # check that reading back delivers the same
+        readback = iris.load_cube(filepath)
+        orig_data, rb_data = cube.data, readback.data
+        assert rb_data.dtype == orig_data.dtype
+        assert rb_data.shape == orig_data.shape
+        assert list(rb_data) == list(orig_data)
 
     def test_write_encoded_overlength__fail(self, tmp_path):
         cube = Cube(np.array("éclair"), attributes={"_Encoding": "utf8"})

--- a/lib/iris/tests/integration/netcdf/test_stringdata.py
+++ b/lib/iris/tests/integration/netcdf/test_stringdata.py
@@ -205,11 +205,6 @@ def load_problems_list():
     return [str(prob) for prob in iris.loading.LOAD_PROBLEMS.problems]
 
 
-@pytest.fixture(autouse=True)
-def tmp_path():
-    return Path("/home/users/patrick.peglar/chararray_testfiles")
-
-
 class TestReadEncodings:
     """Test loading of testfiles with encoded string data."""
 

--- a/lib/iris/tests/unit/fileformats/netcdf/test_bytecoding_datasets.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/test_bytecoding_datasets.py
@@ -210,17 +210,13 @@ class TestWriteStrings:
         expected_bytes = make_bytearray(test_data, strlen)
         check_raw_content(path, "vyxn", expected_bytes)
 
-    @pytest.mark.parametrize("encoding", [None, "ascii"])
-    def test_write_encoding_failure(self, tempdir, encoding):
+    def test_write_encoding_failure(self, tempdir):
         path = tempdir / f"test_bytecoded_writestrings_encoding_{encoding}_fail.nc"
-        ds = make_encoded_dataset(path, strlen=5, encoding=encoding)
+        ds = make_encoded_dataset(path, strlen=5, encoding="ascii")
         v = ds.variables["vxs"]
-        encoding_name = encoding
-        if encoding_name == None:
-            encoding_name = "ascii"
         msg = (
             "String data written to netcdf character variable 'vxs'.*"
-            f" could not be represented in encoding '{encoding_name}'. "
+            f" could not be represented in encoding 'ascii'. "
         )
         with pytest.raises(ValueError, match=msg):
             v[:] = samples_3_nonascii


### PR DESCRIPTION
Closes #7195 

See all the arguments there.

Ideally this would go direct into Iris 3.16, but I fear we just ran out of time.
**If not in 3.16**  we will need to revise this, make controllable (?via FUTURE?) for a backwards-incompatible change.

~WIP: first let's see if any tests fail...~