### PR TITLE
Add step to Cube rolling windows

### DIFF
--- a/changelog/7232.feature.rst
+++ b/changelog/7232.feature.rst
@@ -1,0 +1,3 @@
+:user:`Kkkakania` added a ``step`` argument to
+:meth:`iris.cube.Cube.rolling_window` for creating strided rolling windows.
+(:issue:`7217`)

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -5103,6 +5103,7 @@ x            -              -
         coord: str | AuxCoord | DimCoord,
         aggregator: iris.analysis.Aggregator,
         window: int,
+        step: int = 1,
         **kwargs,
     ) -> Cube:
         """Perform rolling window aggregation on a cube.
@@ -5119,6 +5120,8 @@ x            -              -
             Aggregator to be applied to the data.
         window :
             Size of window to use.
+        step :
+            Size of step between windows.
         **kwargs :
             Aggregator and aggregation function keyword arguments. The weights
             argument to the aggregator, if any, should be a 1d array, cube, or
@@ -5208,6 +5211,8 @@ x            -               -
             raise ValueError(
                 "Cannot perform rolling window with a window size less than 2."
             )
+        if step < 1:
+            raise ValueError("`step` must be at least 1.")
 
         if coord.ndim > 1:
             raise iris.exceptions.CoordinateMultiDimError(coord)
@@ -5228,14 +5233,14 @@ x            -               -
         # old-to-new-coords (to avoid having to use metadata identity)?
         new_cube = iris.util._strip_metadata_from_dims(self, [dimension])
         key = [slice(None, None)] * self.ndim
-        key[dimension] = slice(None, self.shape[dimension] - window + 1)
+        key[dimension] = slice(None, self.shape[dimension] - window + 1, step)
         new_cube = new_cube[tuple(key)]
         if not dataless:
             # take a view of the original data using the rolling_window function
             # this will add an extra dimension to the data at dimension + 1 which
             # represents the rolled window (i.e. will have a length of window)
             rolling_window_data = iris.util.rolling_window(
-                self.core_data(), window=window, axis=dimension
+                self.core_data(), window=window, step=step, axis=dimension
             )
 
         # now update all of the coordinates to reflect the aggregation
@@ -5254,7 +5259,9 @@ x            -               -
                     "coordinate." % coord_.name()
                 )
 
-            new_bounds = iris.util.rolling_window(coord_.core_points(), window)
+            new_bounds = iris.util.rolling_window(
+                coord_.core_points(), window, step=step
+            )
 
             if np.issubdtype(new_bounds.dtype, np.str_):
                 # Handle case where the AuxCoord contains string. The points

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -1057,6 +1057,33 @@ class Test_rolling_window:
         assert res_cube.coord("val") == val_coord
         assert res_cube.coord("month") == month_coord
 
+    def test_step(self, dataless):
+        if dataless:
+            self.cube.data = None
+
+        result = self.cube.rolling_window("val", iris.analysis.MEAN, window=2, step=2)
+
+        assert result.shape == (3,)
+        expected_val = DimCoord(
+            np.array([0.5, 2.5, 4.5]),
+            bounds=np.array([[0, 1], [2, 3], [4, 5]]),
+            long_name="val",
+            units="s",
+        )
+        expected_month = AuxCoord(
+            np.array(["jan|feb", "mar|apr", "may|jun"]),
+            bounds=np.array([["jan", "feb"], ["mar", "apr"], ["may", "jun"]]),
+            long_name="month",
+        )
+        assert result.coord("val") == expected_val
+        assert result.coord("month") == expected_month
+        if not dataless:
+            _shared_utils.assert_array_equal(result.data, [0.5, 2.5, 4.5])
+
+    def test_step_too_small(self):
+        with pytest.raises(ValueError, match="`step` must be at least 1"):
+            self.cube.rolling_window("val", iris.analysis.MEAN, window=2, step=0)
+
     def test_kwargs(self):
         # Rolling window with missing data not tolerated
         window = 2


### PR DESCRIPTION
## Description

Adds a `step` argument to `Cube.rolling_window`, matching the strided-window support already provided by `iris.util.rolling_window`. The default remains `step=1`, so existing calls keep their current behavior.

The step is applied consistently to cube shape selection, data windows, and numeric/string coordinates. Invalid non-positive steps now raise the same clear error as the utility function.

Fixes #7217.

## Checklist

- [x] Included a **What's New** entry
- [x] Incorporated type hints in changed code
- [x] Added tests for data, dataless cubes, coordinates, and validation
- [x] Checked that no benchmark update is needed
- [x] Updated the public method docstring
- [x] Checked that no dependency update is needed

## Validation

- `pytest lib/iris/tests/unit/cube/test_Cube.py -q` (496 passed, 34 skipped)
- `pytest lib/iris/tests/test_analysis.py::TestRollingWindow -q` (9 passed)
- `pre-commit run --files lib/iris/cube.py lib/iris/tests/unit/cube/test_Cube.py changelog/7232.feature.rst`