### PR TITLE
Add option for steps in Cube rolling windows

### DIFF
--- a/changelog/7236.feature.rst
+++ b/changelog/7236.feature.rst
@@ -1,0 +1,2 @@
+:user:`mo-AndrewCreswick` added the option to set the step between
+rolling windows in :meth:`iris.cube.Cube.rolling_window()`. (:issue:`7217`)

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -5103,6 +5103,7 @@ x            -              -
         coord: str | AuxCoord | DimCoord,
         aggregator: iris.analysis.Aggregator,
         window: int,
+        step: int = 1,
         **kwargs,
     ) -> Cube:
         """Perform rolling window aggregation on a cube.
@@ -5119,6 +5120,8 @@ x            -              -
             Aggregator to be applied to the data.
         window :
             Size of window to use.
+        step : int, default=1
+            Size of step between rolling windows.
         **kwargs :
             Aggregator and aggregation function keyword arguments. The weights
             argument to the aggregator, if any, should be a 1d array, cube, or
@@ -5209,6 +5212,9 @@ x            -               -
                 "Cannot perform rolling window with a window size less than 2."
             )
 
+        if step < 1:
+            raise ValueError("`step` must be at least 1.")
+
         if coord.ndim > 1:
             raise iris.exceptions.CoordinateMultiDimError(coord)
 
@@ -5228,14 +5234,14 @@ x            -               -
         # old-to-new-coords (to avoid having to use metadata identity)?
         new_cube = iris.util._strip_metadata_from_dims(self, [dimension])
         key = [slice(None, None)] * self.ndim
-        key[dimension] = slice(None, self.shape[dimension] - window + 1)
+        key[dimension] = slice(None, self.shape[dimension] - window + 1, step)
         new_cube = new_cube[tuple(key)]
         if not dataless:
             # take a view of the original data using the rolling_window function
             # this will add an extra dimension to the data at dimension + 1 which
             # represents the rolled window (i.e. will have a length of window)
             rolling_window_data = iris.util.rolling_window(
-                self.core_data(), window=window, axis=dimension
+                self.core_data(), window, step, dimension
             )
 
         # now update all of the coordinates to reflect the aggregation
@@ -5254,7 +5260,7 @@ x            -               -
                     "coordinate." % coord_.name()
                 )
 
-            new_bounds = iris.util.rolling_window(coord_.core_points(), window)
+            new_bounds = iris.util.rolling_window(coord_.core_points(), window, step)
 
             if np.issubdtype(new_bounds.dtype, np.str_):
                 # Handle case where the AuxCoord contains string. The points

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -1144,6 +1144,38 @@ class Test_rolling_window:
             _shared_utils.assert_array_equal(res_cube.data, [55])
         assert res_cube.units == "kg s"
 
+    def test_step(self):
+        res_cube = self.cube.rolling_window("val", SUM, 3, step=2)
+        _shared_utils.assert_array_equal(res_cube.data, [3, 9])
+
+    def test_invalid_step(self):
+        with pytest.raises(ValueError, match="`step` must be at least 1."):
+            self.cube.rolling_window("val", SUM, 3, step=0)
+
+    def test_step_coord(self, dataless):
+        if dataless:
+            self.cube.data = None
+        # Rolling window with a step applied to the coordinates.
+        res_cube = self.cube.rolling_window("val", self.mock_agg, 3, step=2)
+        val_coord = DimCoord(
+            np.array([1, 3]),
+            bounds=np.array([[0, 2], [2, 4]]),
+            long_name="val",
+            units="s",
+        )
+        month_coord = AuxCoord(
+            np.array(["jan|feb|mar", "mar|apr|may"]),
+            bounds=np.array(
+                [
+                    ["jan", "mar"],
+                    ["mar", "may"],
+                ]
+            ),
+            long_name="month",
+        )
+        assert res_cube.coord("val") == val_coord
+        assert res_cube.coord("month") == month_coord
+
 
 class Test_slices_dim_order:
     """Test the capability of iris.cube.Cube.slices().


### PR DESCRIPTION
## Description

This adds a `step` argument to `iris.cube.Cube.rolling_window` method to make use of the full functionality available in `iris.util.rolling_window`. A default argument of `step=1`  ensures backwards compatibility.

Unit tests added to test the aggregation over rolling windows with a step between windows and also to test that coordinates are handled correctly with a step. The behaviour of the window creation with steps is tested more thoroughly in the unit tests for `iris.util.rolling_window`.

I'm not sure if benchmarking is required for this PR so have not added the label for now.

## Checklist

> [!IMPORTANT]
> **The Iris core developers are here to help!** If anything below is unclear, just post a comment asking for help 😊

- [x] Included a [**What's New**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/documenting/whats_new_contributions.html) entry
- [x] Incorporated [**type hints**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_code_formatting.html#type-hinting) in any changed code
- [x] Checked if [**tests**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_tests.html) need updating
- [ ] Checked if [**benchmarks**](../benchmarks/README.md#writing-benchmarks) need updating
- [x] Checked if **documentation** needs updating
  - [Docstrings](https://scitools-iris.readthedocs.io/en/latest/developers_guide/documenting/docstrings.html) (we love code examples!)
  - [User Manual](https://scitools-iris.readthedocs.io/en/latest/user_manual/) pages
- [x] Checked if [**dependencies**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_ci_tests.html#gha-test-env) need updating
- [x] Confirmed that the GitHub **'checks'** on this PR are passing :white_check_mark:
  _([further reading](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_ci_tests.html))_

---
> [!TIP]
> Things you can trigger on this PR:
>
> - Add this label to trigger benchmarks: https://github.com/SciTools/iris/labels/benchmark_this
> - Visit this URL - swapping `9999` for this PR's number - to re-trigger the [CLA check](https://github.com/SciTools/.github/wiki/Contributor-Licence-Agreement):
>   `https://cla-assistant.io/check/SciTools/iris?pullRequest=9999`
