### PR TITLE
CI compatibility with PROJ 9.8

### DIFF
--- a/changelog/7254.internal.rst
+++ b/changelog/7254.internal.rst
@@ -1,0 +1,1 @@
+:user:`trexfeathers` made CI compatible with PROJ 9.8, including known incompatibilities with Cartopy <0.26 when plotting coastlines.

--- a/lib/iris/tests/_shared_utils.py
+++ b/lib/iris/tests/_shared_utils.py
@@ -1024,8 +1024,9 @@ def env_bin_path(exe_name: Optional[str] = None):
     return exe_path
 
 
+# TODO: Remove this decorator once problematic versions have been phased out
 def skip_proj_9_8_incompatible(func: Callable):
-    """Return a skipper for when PROJ is >=9.8 and Cartopy is <0.26.
+    """A decorator that skips decorated tests when PROJ is >=9.8 and Cartopy is <0.26.
 
     Cartopy v0.26 addresses a known incompatibility with PROJ v9.8:
     https://github.com/SciTools/cartopy/pull/2653

--- a/lib/iris/tests/_shared_utils.py
+++ b/lib/iris/tests/_shared_utils.py
@@ -21,7 +21,7 @@ from pathlib import Path
 import re
 import shutil
 import subprocess
-from typing import Optional
+from typing import Callable, Optional
 import warnings
 import xml.dom.minidom
 import zlib
@@ -1022,6 +1022,30 @@ def env_bin_path(exe_name: Optional[str] = None):
     if exe_name is not None:
         exe_path = exe_path / exe_name
     return exe_path
+
+
+def skip_proj_9_8_incompatible(func: Callable):
+    """Return a skipper for when PROJ is >=9.8 and Cartopy is <0.26.
+
+    Cartopy v0.26 addresses a known incompatibility with PROJ v9.8:
+    https://github.com/SciTools/cartopy/pull/2653
+
+    Implemented as a callable to avoid wasteful top-level import of these
+    packages - _shared_utils is imported by every test module.
+    """
+    import cartopy
+    from packaging.version import Version
+    import pyproj
+
+    cartopy_version = Version(cartopy.__version__)
+    proj_version = Version(pyproj.__proj_version__)
+
+    incompatible = proj_version >= Version("9.8") and cartopy_version < Version("0.26")
+    skip = pytest.mark.skipif(
+        incompatible,
+        reason="Cartopy<0.26 is incompatible with PROJ>=9.8. SciTools/cartopy#2653",
+    )
+    return skip(func)
 
 
 class GraphicsTest:

--- a/lib/iris/tests/test_mapping.py
+++ b/lib/iris/tests/test_mapping.py
@@ -104,6 +104,7 @@ class TestMappingSubRegion(_shared_utils.GraphicsTest):
         # make the data smaller to speed things up.
         self.cube = cube[::10, ::10]
 
+    @_shared_utils.skip_proj_9_8_incompatible
     def test_simple(self):
         # First sub-plot
         plt.subplot(221)
@@ -187,6 +188,7 @@ class TestBoundedCube(_shared_utils.GraphicsTest):
         self.cube.coord("latitude").guess_bounds()
         self.cube.coord("longitude").guess_bounds()
 
+    @_shared_utils.skip_proj_9_8_incompatible
     def test_pcolormesh(self):
         # pcolormesh can only be drawn in native coordinates (or more
         # specifically, in coordinates that don't wrap).
@@ -230,6 +232,7 @@ class TestLimitedAreaCube(_shared_utils.GraphicsTest):
         iplt.outline(self.cube)
         self.check_graphic()
 
+    @_shared_utils.skip_proj_9_8_incompatible
     def test_scatter(self):
         iplt.points(self.cube)
         plt.gca().coastlines("110m")

--- a/lib/iris/tests/test_plot.py
+++ b/lib/iris/tests/test_plot.py
@@ -1024,6 +1024,7 @@ class TestPlottingExceptions:
 
 @_shared_utils.skip_data
 @_shared_utils.skip_plot
+@_shared_utils.skip_proj_9_8_incompatible
 class TestPlotOtherCoordSystems(_shared_utils.GraphicsTest):
     def test_plot_tmerc(self):
         filename = _shared_utils.get_data_path(

--- a/lib/iris/tests/unit/analysis/cartography/test_gridcell_angles.py
+++ b/lib/iris/tests/unit/analysis/cartography/test_gridcell_angles.py
@@ -221,6 +221,7 @@ class TestGridcellAngles:
         # NOTE: although this looks just as bad as 'test_points_array_args',
         # maximum errors there in the end columns are actually > 100 degrees !
 
+    @_shared_utils.skip_proj_9_8_incompatible
     def test_nonlatlon_coord_system(self):
         # Check with points specified in an unexpected coord system.
         cube = sample_2d_latlons(regional=True, rotated=True)
@@ -228,7 +229,6 @@ class TestGridcellAngles:
         _shared_utils.assert_array_all_close(
             result.data,
             self.standard_small_cube_results,
-            atol=0.1,
         )
         # Check that the result has transformed (true-latlon) coordinates.
         assert len(result.coords()) == 2

--- a/lib/iris/tests/unit/analysis/cartography/test_gridcell_angles.py
+++ b/lib/iris/tests/unit/analysis/cartography/test_gridcell_angles.py
@@ -226,7 +226,9 @@ class TestGridcellAngles:
         cube = sample_2d_latlons(regional=True, rotated=True)
         result = gridcell_angles(cube)
         _shared_utils.assert_array_all_close(
-            result.data, self.standard_small_cube_results
+            result.data,
+            self.standard_small_cube_results,
+            atol=0.1,
         )
         # Check that the result has transformed (true-latlon) coordinates.
         assert len(result.coords()) == 2


### PR DESCRIPTION
## Description

DESCRIPTION PENDING

## Checklist

> [!IMPORTANT]
> **The Iris core developers are here to help!** If anything below is unclear, just post a comment asking for help 😊

- [x] Included a [**What's New**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/documenting/whats_new_contributions.html) entry
- [x] Incorporated [**type hints**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_code_formatting.html#type-hinting) in any changed code
- [x] Checked if [**tests**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_tests.html) need updating
- [x] Checked if [**benchmarks**](../benchmarks/README.md#writing-benchmarks) need updating
- [x] Checked if **documentation** needs updating
  - [Docstrings](https://scitools-iris.readthedocs.io/en/latest/developers_guide/documenting/docstrings.html) (we love code examples!)
  - [User Manual](https://scitools-iris.readthedocs.io/en/latest/user_manual/) pages
- [x] Checked if [**dependencies**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_ci_tests.html#gha-test-env) need updating
- [x] Confirmed that the GitHub **'checks'** on this PR are passing :white_check_mark:
  _([further reading](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_ci_tests.html))_

---
> [!TIP]
> Things you can trigger on this PR:
>
> - Add this label to trigger benchmarks: https://github.com/SciTools/iris/labels/benchmark_this
> - Visit this URL - swapping `9999` for this PR's number - to re-trigger the [CLA check](https://github.com/SciTools/.github/wiki/Contributor-Licence-Agreement):
>   `https://cla-assistant.io/check/SciTools/iris?pullRequest=9999`
