### PR TITLE
Add aux_factory HybridLogPressureFactory for atmosphere_hybrid_sigma_ln_pressure_coordinate

### DIFF
--- a/changelog/7255.feature.rst
+++ b/changelog/7255.feature.rst
@@ -1,0 +1,1 @@
+:user:`k-a-webb` added aux_factory :func:`~iris.aux_factory.HybridLogPressureFactory`.

--- a/lib/iris/aux_factory.py
+++ b/lib/iris/aux_factory.py
@@ -1004,7 +1004,7 @@ class HybridLogPressureFactory(AuxCoordFactory):
 
         # Check that provided coords meet necessary conditions.
         self._check_dependencies(eta, sigma, surface_air_pressure, reference_air_pressure)
-        self.units = surface_air_pressure.units
+        self.units = reference_air_pressure.units
 
         self.eta = eta
         self.sigma = sigma
@@ -1017,7 +1017,7 @@ class HybridLogPressureFactory(AuxCoordFactory):
     @staticmethod
     def _check_dependencies(eta, sigma, surface_air_pressure, reference_air_pressure):
         # Check for sufficient coordinates.
-        if (sigma is None or surface_air_pressure is None ) and eta is None:
+        if (reference_air_pressure is None and surface_air_pressure is None) or eta is None or sigma is None:
             print( eta is not None, sigma is not None, surface_air_pressure is not None, reference_air_pressure is not None)
             msg = (
                 "Unable to construct hybrid log-pressure coordinate factory "
@@ -1072,7 +1072,7 @@ class HybridLogPressureFactory(AuxCoordFactory):
         if surface_air_pressure is not None:
             units = surface_air_pressure.units
         else:
-            units = sigma.units
+            units = reference_air_pressure.units
 
         if not units.is_convertible("Pa"):
             msg = (

--- a/lib/iris/aux_factory.py
+++ b/lib/iris/aux_factory.py
@@ -976,6 +976,195 @@ class HybridPressureFactory(AuxCoordFactory):
         return hybrid_pressure
 
 
+class HybridLogPressureFactory(AuxCoordFactory):
+    """Define a hybrid log-pressure coordinate factory."""
+
+    def __init__(self, eta=None, sigma=None, surface_air_pressure=None, reference_air_pressure=None):
+        """Create a hybrid-height coordinate factory with the following formula.
+
+        .. math::
+            p = p0 * eta * (ps/p0)**b
+
+
+        Parameters
+        ----------
+        eta : Coord
+            The coordinate providing the `eta`, hybrid sigma log-pressure coordinate, term.
+        sigma : Coord
+            The coordinate providing the `b` term.
+        surface_air_pressure : Coord
+            The coordinate providing the `ps` term.
+        reference_air_pressure : Coord
+            The coordinate providing the `p0` term.
+        """
+
+        # Configure the metadata manager.
+        self._metadata_manager = metadata_manager_factory(CoordMetadata)
+        super().__init__()
+
+        # Check that provided coords meet necessary conditions.
+        self._check_dependencies(eta, sigma, surface_air_pressure, reference_air_pressure)
+        self.units = surface_air_pressure.units
+
+        self.eta = eta
+        self.sigma = sigma
+        self.surface_air_pressure = surface_air_pressure
+        self.reference_air_pressure = reference_air_pressure
+
+        self.standard_name = "air_pressure"
+        self.attributes = {}
+
+    @staticmethod
+    def _check_dependencies(eta, sigma, surface_air_pressure, reference_air_pressure):
+        # Check for sufficient coordinates.
+        if (sigma is None or surface_air_pressure is None ) and eta is None:
+            print( eta is not None, sigma is not None, surface_air_pressure is not None, reference_air_pressure is not None)
+            msg = (
+                "Unable to construct hybrid log-pressure coordinate factory "
+                "due to insufficient source coordinates."
+            )
+            raise ValueError(msg)
+
+        # Check bounds.
+        if eta.nbounds not in (0, 2):
+            raise ValueError(
+                "Invalid eta coordinate: must have either 0 or 2 bounds."
+            )
+        if sigma.nbounds not in (0, 2):
+            raise ValueError(
+                "Invalid sigma coordinate: must have either 0 or 2 bounds."
+            )
+        if surface_air_pressure and surface_air_pressure.nbounds:
+            msg = (
+                "Surface pressure coordinate {!r} has bounds. These will"
+                " be disregarded.".format(surface_air_pressure.name())
+            )
+            warnings.warn(msg, category=IrisIgnoringBoundsWarning, stacketael=2)
+        if reference_air_pressure and reference_air_pressure.nbounds:
+            msg = (
+                "Reference pressure coordinate {!r} has bounds. These will"
+                " be disregarded.".format(reference_air_pressure.name())
+            )
+            warnings.warn(msg, category=IrisIgnoringBoundsWarning, stacketael=2)
+
+        # Check units.
+        if eta.units.is_unknown():
+            # Be graceful, and promote unknown to dimensionless units.
+            eta.units = cf_units.Unit("1")
+        if not eta.units.is_dimensionless():
+            raise ValueError("Invalid units: eta must be dimensionless.")
+
+        if sigma.units.is_unknown():
+            # Be graceful, and promote unknown to dimensionless units.
+            sigma.units = cf_units.Unit("1")
+        if not sigma.units.is_dimensionless():
+            raise ValueError("Invalid units: sigma must be dimensionless.")
+
+        if (
+            surface_air_pressure and reference_air_pressure.units != surface_air_pressure.units
+        ):
+            msg = (
+                "Incompatible units: reference_air_pressure and "
+                "surface_air_pressure must have the same units."
+            )
+            raise ValueError(msg)
+
+        if surface_air_pressure is not None:
+            units = surface_air_pressure.units
+        else:
+            units = sigma.units
+
+        if not units.is_convertible("Pa"):
+            msg = (
+                "Invalid units: reference_air_pressure and "
+                "surface_air_pressure must have units of pressure."
+            )
+            raise ValueError(msg)
+
+    @property
+    def dependencies(self):
+        """Return a dict mapping from constructor arg names to coordinates.
+
+        Returns a dictionary mapping from constructor argument names to
+        the corresponding coordinates.
+
+        """
+        return {
+            "eta": self.eta,
+            "sigma": self.sigma,
+            "surface_air_pressure": self.surface_air_pressure,
+            "reference_air_pressure": self.reference_air_pressure,
+        }
+
+    def _calculate_array(self, eta, sigma, surface_air_pressure, reference_air_pressure):
+        return reference_air_pressure * eta * (surface_air_pressure/reference_air_pressure)**sigma
+
+    def make_coord(self, coord_dims_func):
+        """Return a new :class:`iris.coords.AuxCoord` as defined by this factory.
+
+        Parameters
+        ----------
+        coord_dims_func :
+            A callable which can return the list of dimensions relevant
+            to a given coordinate.
+
+            See :meth:`iris.cube.Cube.coord_dims()`.
+
+        """
+        
+        # Which dimensions are relevant?
+        derived_dims = self.derived_dims(coord_dims_func)
+        dependency_dims = self._dependency_dims(coord_dims_func)
+
+        # Build the points array.
+        nd_points_by_key = self._remap(dependency_dims, derived_dims)
+        points = self._derive_array(
+            nd_points_by_key["eta"],
+            nd_points_by_key["sigma"],
+            nd_points_by_key["surface_air_pressure"],
+            nd_points_by_key["reference_air_pressure"],
+        )
+
+        bounds = None
+        if (self.eta.nbounds) or (self.sigma.nbounds):
+            # Build the bounds array.
+            nd_values_by_key = self._remap_with_bounds(dependency_dims, derived_dims)
+            eta = nd_values_by_key["eta"]
+            sigma = nd_values_by_key["sigma"]
+            surface_air_pressure = nd_values_by_key["surface_air_pressure"]
+            reference_air_pressure = nd_values_by_key["reference_air_pressure"]
+            ok_bound_shapes = [(), (1,), (2,)]
+            if eta.shape[-1:] not in ok_bound_shapes:
+                raise ValueError("Invalid eta coordinate bounds.")
+            if sigma.shape[-1:] not in ok_bound_shapes:
+                raise ValueError("Invalid sigma coordinate bounds.")
+            if reference_air_pressure.shape[-1:] not in ok_bound_shapes:
+                raise ValueError("Invalid reference_air_pressure coordinate bounds.")
+            if surface_air_pressure.shape[-1:] not in [(), (1,)]:
+                warnings.warn(
+                    "Surface pressure coordinate has bounds. "
+                    "These are being disregarded.",
+                    category=IrisIgnoringBoundsWarning,
+                )
+                surface_air_pressure_pts = nd_points_by_key["surface_air_pressure"]
+                bds_shape = list(surface_air_pressure_pts.shape) + [1]
+                surface_air_pressure = surface_air_pressure_pts.reshape(bds_shape)
+
+            bounds = self._derive_array(eta, sigma, surface_air_pressure, reference_air_pressure)
+
+        hybrid_log_pressure = iris.coords.AuxCoord(
+            points,
+            standard_name=self.standard_name,
+            long_name=self.long_name,
+            var_name=self.var_name,
+            units=self.units,
+            bounds=bounds,
+            attributes=self.attributes,
+            coord_system=self.coord_system,
+        )
+        return hybrid_log_pressure
+
+
 class OceanSigmaZFactory(AuxCoordFactory):
     """Defines an ocean sigma over z coordinate factory."""
 

--- a/lib/iris/aux_factory.py
+++ b/lib/iris/aux_factory.py
@@ -1029,12 +1029,6 @@ class HybridLogPressureFactory(AuxCoordFactory):
             or eta is None
             or sigma is None
         ):
-            print(
-                eta is not None,
-                sigma is not None,
-                surface_air_pressure is not None,
-                reference_air_pressure is not None,
-            )
             msg = (
                 "Unable to construct hybrid log-pressure coordinate factory "
                 "due to insufficient source coordinates."
@@ -1067,7 +1061,6 @@ class HybridLogPressureFactory(AuxCoordFactory):
             eta.units = cf_units.Unit("1")
         if not eta.units.is_dimensionless():
             raise ValueError("Invalid units: eta must be dimensionless.")
-
         if sigma.units.is_unknown():
             # Be graceful, and promote unknown to dimensionless units.
             sigma.units = cf_units.Unit("1")

--- a/lib/iris/aux_factory.py
+++ b/lib/iris/aux_factory.py
@@ -979,7 +979,13 @@ class HybridPressureFactory(AuxCoordFactory):
 class HybridLogPressureFactory(AuxCoordFactory):
     """Define a hybrid log-pressure coordinate factory."""
 
-    def __init__(self, eta=None, sigma=None, surface_air_pressure=None, reference_air_pressure=None):
+    def __init__(
+        self,
+        eta=None,
+        sigma=None,
+        surface_air_pressure=None,
+        reference_air_pressure=None,
+    ):
         """Create a hybrid-height coordinate factory with the following formula.
 
         .. math::
@@ -997,13 +1003,14 @@ class HybridLogPressureFactory(AuxCoordFactory):
         reference_air_pressure : Coord
             The coordinate providing the `p0` term.
         """
-
         # Configure the metadata manager.
         self._metadata_manager = metadata_manager_factory(CoordMetadata)
         super().__init__()
 
         # Check that provided coords meet necessary conditions.
-        self._check_dependencies(eta, sigma, surface_air_pressure, reference_air_pressure)
+        self._check_dependencies(
+            eta, sigma, surface_air_pressure, reference_air_pressure
+        )
         self.units = reference_air_pressure.units
 
         self.eta = eta
@@ -1017,8 +1024,17 @@ class HybridLogPressureFactory(AuxCoordFactory):
     @staticmethod
     def _check_dependencies(eta, sigma, surface_air_pressure, reference_air_pressure):
         # Check for sufficient coordinates.
-        if (reference_air_pressure is None and surface_air_pressure is None) or eta is None or sigma is None:
-            print( eta is not None, sigma is not None, surface_air_pressure is not None, reference_air_pressure is not None)
+        if (
+            (reference_air_pressure is None and surface_air_pressure is None)
+            or eta is None
+            or sigma is None
+        ):
+            print(
+                eta is not None,
+                sigma is not None,
+                surface_air_pressure is not None,
+                reference_air_pressure is not None,
+            )
             msg = (
                 "Unable to construct hybrid log-pressure coordinate factory "
                 "due to insufficient source coordinates."
@@ -1027,9 +1043,7 @@ class HybridLogPressureFactory(AuxCoordFactory):
 
         # Check bounds.
         if eta.nbounds not in (0, 2):
-            raise ValueError(
-                "Invalid eta coordinate: must have either 0 or 2 bounds."
-            )
+            raise ValueError("Invalid eta coordinate: must have either 0 or 2 bounds.")
         if sigma.nbounds not in (0, 2):
             raise ValueError(
                 "Invalid sigma coordinate: must have either 0 or 2 bounds."
@@ -1061,7 +1075,8 @@ class HybridLogPressureFactory(AuxCoordFactory):
             raise ValueError("Invalid units: sigma must be dimensionless.")
 
         if (
-            surface_air_pressure and reference_air_pressure.units != surface_air_pressure.units
+            surface_air_pressure
+            and reference_air_pressure.units != surface_air_pressure.units
         ):
             msg = (
                 "Incompatible units: reference_air_pressure and "
@@ -1096,8 +1111,14 @@ class HybridLogPressureFactory(AuxCoordFactory):
             "reference_air_pressure": self.reference_air_pressure,
         }
 
-    def _calculate_array(self, eta, sigma, surface_air_pressure, reference_air_pressure):
-        return reference_air_pressure * eta * (surface_air_pressure/reference_air_pressure)**sigma
+    def _calculate_array(
+        self, eta, sigma, surface_air_pressure, reference_air_pressure
+    ):
+        return (
+            reference_air_pressure
+            * eta
+            * (surface_air_pressure / reference_air_pressure) ** sigma
+        )
 
     def make_coord(self, coord_dims_func):
         """Return a new :class:`iris.coords.AuxCoord` as defined by this factory.
@@ -1111,7 +1132,6 @@ class HybridLogPressureFactory(AuxCoordFactory):
             See :meth:`iris.cube.Cube.coord_dims()`.
 
         """
-        
         # Which dimensions are relevant?
         derived_dims = self.derived_dims(coord_dims_func)
         dependency_dims = self._dependency_dims(coord_dims_func)
@@ -1150,7 +1170,9 @@ class HybridLogPressureFactory(AuxCoordFactory):
                 bds_shape = list(surface_air_pressure_pts.shape) + [1]
                 surface_air_pressure = surface_air_pressure_pts.reshape(bds_shape)
 
-            bounds = self._derive_array(eta, sigma, surface_air_pressure, reference_air_pressure)
+            bounds = self._derive_array(
+                eta, sigma, surface_air_pressure, reference_air_pressure
+            )
 
         hybrid_log_pressure = iris.coords.AuxCoord(
             points,

--- a/lib/iris/common/metadata.py
+++ b/lib/iris/common/metadata.py
@@ -104,7 +104,7 @@ def hexdigest(item):
         # string representation of the provided item instead, but
         # also fold in the object type...
         parts = (type(item), item)
-        result = xxh64_hexdigest(str(parts))
+        result = xxh64_hexdigest(str(parts).encode("utf-8"))
 
     return result
 

--- a/lib/iris/fileformats/cf.py
+++ b/lib/iris/fileformats/cf.py
@@ -64,6 +64,7 @@ _CF_ATTRS_IGNORE = set(["_FillValue", "add_offset", "missing_value", "scale_fact
 reference_terms = dict(
     atmosphere_sigma_coordinate=["ps"],
     atmosphere_hybrid_sigma_pressure_coordinate=["ps"],
+    atmosphere_hybrid_sigma_ln_pressure_coordinate=["ps","p0","lev"],
     atmosphere_hybrid_height_coordinate=["orog"],
     atmosphere_sleve_coordinate=["zsurf1", "zsurf2"],
     ocean_sigma_coordinate=["eta", "depth"],
@@ -1556,6 +1557,7 @@ class CFReader:
             ) -> None:
                 """Sanity check dimensionality."""
                 var = self.cf_group[var_name]
+
                 # No span check is necessary if variable is attached to a mesh.
                 if (is_mesh_var or var.spans(cf_variable)) and not var._to_be_promoted:
                     cf_group[var_name] = var
@@ -1604,6 +1606,7 @@ class CFReader:
                     warn=False,
                     **kwargs,
                 )
+
                 # Sanity check dimensionality coverage.
                 for cf_name in match:
                     _span_check(cf_name)
@@ -1620,6 +1623,7 @@ class CFReader:
 
             # Build CF data variable relationships.
             if isinstance(cf_variable, CFDataVariable):
+
                 # Add global netCDF attributes.
                 cf_group.global_attributes.update(self.cf_group.global_attributes)
                 # Add appropriate "dimensioned" CF coordinate variables.

--- a/lib/iris/fileformats/cf.py
+++ b/lib/iris/fileformats/cf.py
@@ -64,7 +64,7 @@ _CF_ATTRS_IGNORE = set(["_FillValue", "add_offset", "missing_value", "scale_fact
 reference_terms = dict(
     atmosphere_sigma_coordinate=["ps"],
     atmosphere_hybrid_sigma_pressure_coordinate=["ps"],
-    atmosphere_hybrid_sigma_ln_pressure_coordinate=["ps","p0","lev"],
+    atmosphere_hybrid_sigma_ln_pressure_coordinate=["ps", "p0", "lev"],
     atmosphere_hybrid_height_coordinate=["orog"],
     atmosphere_sleve_coordinate=["zsurf1", "zsurf2"],
     ocean_sigma_coordinate=["eta", "depth"],
@@ -1623,7 +1623,6 @@ class CFReader:
 
             # Build CF data variable relationships.
             if isinstance(cf_variable, CFDataVariable):
-
                 # Add global netCDF attributes.
                 cf_group.global_attributes.update(self.cf_group.global_attributes)
                 # Add appropriate "dimensioned" CF coordinate variables.

--- a/lib/iris/fileformats/netcdf/loader.py
+++ b/lib/iris/fileformats/netcdf/loader.py
@@ -30,8 +30,8 @@ from iris._lazy_data import as_lazy_data
 from iris.aux_factory import (
     AtmosphereSigmaFactory,
     HybridHeightFactory,
-    HybridPressureFactory,
     HybridLogPressureFactory,
+    HybridPressureFactory,
     OceanSFactory,
     OceanSg1Factory,
     OceanSg2Factory,
@@ -579,7 +579,7 @@ def _load_aux_factory(engine, cube):
             factory = HybridPressureFactory(delta, sigma, surface_air_pressure)
         elif formula_type == "atmosphere_hybrid_sigma_ln_pressure_coordinate":
             eta = coord_from_term("lev")
-            if eta is None:              
+            if eta is None:
                 for coord, cf_var_name in engine.cube_parts["coordinates"]:
                     if cf_var_name == "lev":
                         eta = coord
@@ -592,7 +592,9 @@ def _load_aux_factory(engine, cube):
             sigma = coord_from_term("b")
             surface_air_pressure = coord_from_term("ps")
             reference_air_pressure = coord_from_term("p0")
-            factory = HybridLogPressureFactory(eta, sigma, surface_air_pressure, reference_air_pressure)
+            factory = HybridLogPressureFactory(
+                eta, sigma, surface_air_pressure, reference_air_pressure
+            )
         elif formula_type == "ocean_sigma_z_coordinate":
             sigma = coord_from_term("sigma")
             eta = coord_from_term("eta")

--- a/lib/iris/fileformats/netcdf/loader.py
+++ b/lib/iris/fileformats/netcdf/loader.py
@@ -31,6 +31,7 @@ from iris.aux_factory import (
     AtmosphereSigmaFactory,
     HybridHeightFactory,
     HybridPressureFactory,
+    HybridLogPressureFactory,
     OceanSFactory,
     OceanSg1Factory,
     OceanSg2Factory,
@@ -502,6 +503,7 @@ def _load_aux_factory(engine, cube):
         "atmosphere_sigma_coordinate",
         "atmosphere_hybrid_height_coordinate",
         "atmosphere_hybrid_sigma_pressure_coordinate",
+        "atmosphere_hybrid_sigma_ln_pressure_coordinate",
         "ocean_sigma_z_coordinate",
         "ocean_sigma_coordinate",
         "ocean_s_coordinate",
@@ -575,6 +577,22 @@ def _load_aux_factory(engine, cube):
             sigma = coord_from_term("b")
             surface_air_pressure = coord_from_term("ps")
             factory = HybridPressureFactory(delta, sigma, surface_air_pressure)
+        elif formula_type == "atmosphere_hybrid_sigma_ln_pressure_coordinate":
+            eta = coord_from_term("lev")
+            if eta is None:              
+                for coord, cf_var_name in engine.cube_parts["coordinates"]:
+                    if cf_var_name == "lev":
+                        eta = coord
+            if eta is None:
+                warnings.warn(
+                    "Unable to find coordinate for variable lev",
+                    category=iris.warnings.IrisFactoryCoordNotFoundWarning,
+                )
+
+            sigma = coord_from_term("b")
+            surface_air_pressure = coord_from_term("ps")
+            reference_air_pressure = coord_from_term("p0")
+            factory = HybridLogPressureFactory(eta, sigma, surface_air_pressure, reference_air_pressure)
         elif formula_type == "ocean_sigma_z_coordinate":
             sigma = coord_from_term("sigma")
             eta = coord_from_term("eta")

--- a/lib/iris/fileformats/netcdf/saver.py
+++ b/lib/iris/fileformats/netcdf/saver.py
@@ -43,8 +43,8 @@ from iris._lazy_data import _co_realise_lazy_arrays, is_lazy_data
 from iris.aux_factory import (
     AtmosphereSigmaFactory,
     HybridHeightFactory,
-    HybridPressureFactory,
     HybridLogPressureFactory,
+    HybridPressureFactory,
     OceanSFactory,
     OceanSg1Factory,
     OceanSg2Factory,

--- a/lib/iris/fileformats/netcdf/saver.py
+++ b/lib/iris/fileformats/netcdf/saver.py
@@ -44,6 +44,7 @@ from iris.aux_factory import (
     AtmosphereSigmaFactory,
     HybridHeightFactory,
     HybridPressureFactory,
+    HybridLogPressureFactory,
     OceanSFactory,
     OceanSg1Factory,
     OceanSg2Factory,
@@ -159,6 +160,11 @@ _FACTORY_DEFNS = {
         primary="delta",
         std_name="atmosphere_hybrid_sigma_pressure_coordinate",
         formula_terms_format="ap: {delta} b: {sigma} ps: {surface_air_pressure}",
+    ),
+    HybridLogPressureFactory: _FactoryDefn(
+        primary="eta",
+        std_name="atmosphere_hybrid_sigma_ln_pressure_coordinate",
+        formula_terms_format="eta: {eta} b: {sigma} ps: {surface_air_pressure} p0: {reference_air_pressure}",
     ),
     OceanSigmaZFactory: _FactoryDefn(
         primary="zlev",

--- a/lib/iris/tests/integration/netcdf/test_aux_factories.py
+++ b/lib/iris/tests/integration/netcdf/test_aux_factories.py
@@ -132,6 +132,7 @@ class TestHybridLogPressure:
         other_cube = iris.load_cube(other_filename, "air_potential_temperature")
         assert cube == other_cube
 
+
 @_shared_utils.skip_data
 class TestSaveMultipleAuxFactories:
     def test_hybrid_height_and_pressure(self, request, tmp_path):

--- a/lib/iris/tests/integration/netcdf/test_aux_factories.py
+++ b/lib/iris/tests/integration/netcdf/test_aux_factories.py
@@ -86,6 +86,53 @@ class TestHybridPressure:
 
 
 @_shared_utils.skip_data
+class TestHybridLogPressure:
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        # Modify stock cube so it is suitable to have a
+        # hybrid pressure factory added to it.
+        cube = stock.realistic_4d_no_derived()
+        cube.coord("surface_altitude").rename("surface_air_pressure")
+        cube.coord("surface_air_pressure").units = "Pa"
+        cube.coord("level_height").rename("level_pressure")
+        cube.coord("level_pressure").units = "Pa"
+
+        reference_air_pressure = iris.coords.AuxCoord(
+            cube.coord("level_pressure").points * 0,
+            standard_name="reference_air_pressure_for_atmosphere_vertical_coordinate",
+            long_name="vertical coordinate formula term: reference pressure",
+            var_name="p0",
+            units=cube.coord("level_pressure").units,
+        )
+
+        # Construct and add hybrid pressure factory.
+        factory = iris.aux_factory.HybridLogPressureFactory(
+            cube.coord("level_pressure"),
+            cube.coord("sigma"),
+            cube.coord("surface_air_pressure"),
+            reference_air_pressure,
+        )
+        cube.add_aux_factory(factory)
+        self.cube = cube
+
+    def test_save(self, request, tmp_path):
+        filename = tmp_path / "fn.nc"
+        iris.save(self.cube, filename)
+        _shared_utils.assert_CDL(request, filename)
+
+    def test_save_load_loop(self, tmp_path):
+        # Tests an issue where the variable names in the formula
+        # terms changed to the standard_names instead of the variable names
+        # when loading a previously saved cube.
+        filename = tmp_path / "fn.nc"
+        other_filename = tmp_path / "ofn.nc"
+        iris.save(self.cube, filename)
+        cube = iris.load_cube(filename, "air_potential_temperature")
+        iris.save(cube, other_filename)
+        other_cube = iris.load_cube(other_filename, "air_potential_temperature")
+        assert cube == other_cube
+
+@_shared_utils.skip_data
 class TestSaveMultipleAuxFactories:
     def test_hybrid_height_and_pressure(self, request, tmp_path):
         cube = stock.realistic_4d()

--- a/lib/iris/tests/test_hybrid.py
+++ b/lib/iris/tests/test_hybrid.py
@@ -10,7 +10,11 @@ import numpy as np
 import pytest
 
 import iris
-from iris.aux_factory import HybridHeightFactory, HybridPressureFactory, HybridLogPressureFactory
+from iris.aux_factory import (
+    HybridHeightFactory,
+    HybridLogPressureFactory,
+    HybridPressureFactory,
+)
 from iris.tests import _shared_utils
 import iris.tests.stock
 from iris.warnings import IrisIgnoringBoundsWarning
@@ -219,7 +223,6 @@ class TestHybridPressure:
         msg = "Surface pressure.* bounds.* being disregarded"
         with pytest.warns(IrisIgnoringBoundsWarning, match=msg):
             self.cube.coord("air_pressure")
-
 
 
 @_shared_utils.skip_data

--- a/lib/iris/tests/test_hybrid.py
+++ b/lib/iris/tests/test_hybrid.py
@@ -10,7 +10,7 @@ import numpy as np
 import pytest
 
 import iris
-from iris.aux_factory import HybridHeightFactory, HybridPressureFactory
+from iris.aux_factory import HybridHeightFactory, HybridPressureFactory, HybridLogPressureFactory
 from iris.tests import _shared_utils
 import iris.tests.stock
 from iris.warnings import IrisIgnoringBoundsWarning
@@ -204,6 +204,90 @@ class TestHybridPressure:
         with pytest.warns(IrisIgnoringBoundsWarning):
             with contextlib.suppress(ValueError):
                 _ = HybridPressureFactory(sigma=sigma, surface_air_pressure=sigma)
+
+    def test_bounded_surface_pressure(self):
+        # Start with everything normal
+        surface_pressure = self.cube.coord("surface_air_pressure")
+        pressure = self.cube.coord("air_pressure")
+        assert isinstance(pressure.bounds, np.ndarray)
+
+        # Make sure pressure still works OK if surface pressure was messed
+        # with *after* pressure was created.
+        surface_pressure.bounds = np.zeros(surface_pressure.shape + (4,))
+
+        # Check that air_pressure derivation now issues a warning.
+        msg = "Surface pressure.* bounds.* being disregarded"
+        with pytest.warns(IrisIgnoringBoundsWarning, match=msg):
+            self.cube.coord("air_pressure")
+
+
+
+@_shared_utils.skip_data
+class TestHybridLogPressure:
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        # Convert the hybrid-height into hybrid-pressure...
+        cube = iris.tests.stock.realistic_4d()
+
+        # Get rid of the normal hybrid-height factory.
+        factory = cube.aux_factory(name="altitude")
+        cube.remove_aux_factory(factory)
+
+        # Mangle the height coords into pressure coords.
+        eta = cube.coord("level_height")
+        eta.rename("level_pressure")
+        eta.units = "Pa"
+        sigma = cube.coord("sigma")
+        ps = cube.coord("surface_altitude")
+        ps.rename("surface_air_pressure")
+        ps.units = "Pa"
+
+        ref = iris.coords.AuxCoord(
+            eta.points * 0,
+            standard_name="reference_air_pressure_for_atmosphere_vertical_coordinate",
+            long_name="vertical coordinate formula term: reference pressure",
+            var_name="p0",
+            units=eta.units,
+        )
+
+        factory = HybridLogPressureFactory(eta, sigma, ps, ref)
+        cube.add_aux_factory(factory)
+        self.cube = cube
+        self.air_pressure = self.cube.coord("air_pressure")
+
+    def test_metadata(self):
+        assert self.air_pressure.units == "Pa"
+        assert self.air_pressure.coord_system is None
+        assert self.air_pressure.attributes == {}
+
+    def test_points(self):
+        points = self.air_pressure.points
+        assert points.dtype == np.float32
+        assert points.min() == pytest.approx(np.float32(191.84892))
+        assert points.max() == pytest.approx(np.float32(40000))
+
+        # Convert the reference surface to float64 and check the
+        # derived coordinate becomes float64.
+        temp = self.cube.coord("surface_air_pressure").points
+        temp = temp.astype("f8")
+        self.cube.coord("surface_air_pressure").points = temp
+        points = self.cube.coord("air_pressure").points
+        assert points.dtype == np.float64
+        assert points.min() == pytest.approx(191.8489257)
+        assert points.max() == pytest.approx(40000)
+
+    def test_invalid_dependencies(self):
+        # Must have either delta or surface_air_pressure
+        with pytest.raises(ValueError, match="insufficient source coordinates"):
+            _ = HybridLogPressureFactory()
+        sigma = self.cube.coord("sigma")
+        with pytest.raises(ValueError, match="insufficient source coordinates"):
+            _ = HybridLogPressureFactory(sigma=sigma)
+
+        # Surface pressure must not have bounds
+        with pytest.warns(IrisIgnoringBoundsWarning):
+            with contextlib.suppress(ValueError):
+                _ = HybridLogPressureFactory(sigma=sigma, surface_air_pressure=sigma)
 
     def test_bounded_surface_pressure(self):
         # Start with everything normal

--- a/lib/iris/tests/unit/aux_factory/test_HybridLogPressureFactory.py
+++ b/lib/iris/tests/unit/aux_factory/test_HybridLogPressureFactory.py
@@ -78,9 +78,7 @@ class Test___init__:
 
     def test_incompatible_surface_air_pressure_units(self):
         self.surface_air_pressure.units = cf_units.Unit("unknown")
-        msg = (
-            "Incompatible units: reference_air_pressure and surface_air_pressure must have the same units."
-        )
+        msg = "Incompatible units: reference_air_pressure and surface_air_pressure must have the same units."
         with pytest.raises(ValueError, match=msg):
             HybridLogPressureFactory(
                 eta=self.eta,
@@ -93,9 +91,9 @@ class Test___init__:
         self.reference_air_pressure.units = cf_units.Unit("hPa")
         self.surface_air_pressure.units = cf_units.Unit("Pa")
         msg = (
-                "Incompatible units: reference_air_pressure and "
-                "surface_air_pressure must have the same units."
-            )
+            "Incompatible units: reference_air_pressure and "
+            "surface_air_pressure must have the same units."
+        )
         with pytest.raises(ValueError, match=msg):
             HybridLogPressureFactory(
                 eta=self.eta,
@@ -171,7 +169,12 @@ class Test_dependencies:
 class Test_make_coord:
     @staticmethod
     def coords_dims_func(coord):
-        mapping = dict(level_pressure=(0,), sigma=(0,), surface_air_pressure=(1, 2), reference_air_pressure=(0,))
+        mapping = dict(
+            level_pressure=(0,),
+            sigma=(0,),
+            surface_air_pressure=(1, 2),
+            reference_air_pressure=(0,),
+        )
         return mapping[coord.name()]
 
     @pytest.fixture(autouse=True)
@@ -215,7 +218,11 @@ class Test_make_coord:
         expected_coord = iris.coords.AuxCoord(
             expected_points, standard_name="air_pressure", units="Pa"
         )
-        factory = HybridLogPressureFactory(eta=self.eta, sigma=self.sigma, reference_air_pressure=self.reference_air_pressure)
+        factory = HybridLogPressureFactory(
+            eta=self.eta,
+            sigma=self.sigma,
+            reference_air_pressure=self.reference_air_pressure,
+        )
         derived_coord = factory.make_coord(self.coords_dims_func)
 
         assert derived_coord == expected_coord

--- a/lib/iris/tests/unit/aux_factory/test_HybridLogPressureFactory.py
+++ b/lib/iris/tests/unit/aux_factory/test_HybridLogPressureFactory.py
@@ -1,0 +1,328 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the BSD license.
+# See LICENSE in the root of the repository for full licensing details.
+"""Unit tests for the
+`iris.aux_factory.HybridLogPressureFactory` class.
+
+"""
+
+from unittest.mock import Mock
+
+import cf_units
+import numpy as np
+import pytest
+
+import iris
+from iris.aux_factory import HybridLogPressureFactory
+
+
+def create_default_sample_parts(self):
+    self.eta = Mock(units=cf_units.Unit("Pa"), nbounds=0)
+    self.sigma = Mock(units=cf_units.Unit("1"), nbounds=0)
+    self.surface_air_pressure = Mock(units=cf_units.Unit("Pa"), nbounds=0)
+    self.reference_air_pressure = Mock(units=cf_units.Unit("Pa"), nbounds=0)
+    self.factory = HybridLogPressureFactory(
+        eat=self.eta,
+        sigma=self.sigma,
+        surface_air_pressure=self.surface_air_pressure,
+        reference_air_pressure=self.reference_air_pressure,
+    )
+
+
+class Test___init__:
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        create_default_sample_parts(self)
+
+    def test_insufficient_coords(self):
+        msg = "Unable to construct hybrid log-pressure coordinate factory due to insufficient source coordinates."
+        with pytest.raises(ValueError, match=msg):
+            HybridLogPressureFactory()
+        with pytest.raises(ValueError, match=msg):
+            HybridLogPressureFactory(
+                eta=None, sigma=self.sigma, surface_air_pressure=None, reference_air_pressure=None
+            )
+        with pytest.raises(ValueError, match=msg):
+            HybridLogPressureFactory(
+                eta=None,
+                sigma=None,
+                surface_air_pressure=self.surface_air_pressure,
+                reference_air_pressure=self.reference_air_pressure,
+            )
+
+    def test_incompatible_eta_units(self):
+        self.eta.units = cf_units.Unit("m")
+        msg = "Incompatible units: eta and surface_air_pressure must have the same units."
+        with pytest.raises(ValueError, match=msg):
+            HybridLogPressureFactory(
+                eta=self.eta,
+                sigma=self.sigma,
+                surface_air_pressure=self.surface_air_pressure,
+                reference_air_pressure=self.reference_air_pressure,
+            )
+
+    def test_incompatible_sigma_units(self):
+        self.sigma.units = cf_units.Unit("Pa")
+        msg = "Invalid units: sigma must be dimensionless."
+        with pytest.raises(ValueError, match=msg):
+            HybridLogPressureFactory(
+                eta=self.eta,
+                sigma=self.sigma,
+                surface_air_pressure=self.surface_air_pressure,
+                reference_air_pressure=self.reference_air_pressure,
+            )
+
+    def test_incompatible_surface_air_pressure_units(self):
+        self.surface_air_pressure.units = cf_units.Unit("unknown")
+        msg = "Incompatible units: eta and surface_air_pressure must have the same units."
+        with pytest.raises(ValueError, match=msg):
+            HybridLogPressureFactory(
+                eta=self.eta,
+                sigma=self.sigma,
+                surface_air_pressure=self.surface_air_pressure,
+                reference_air_pressure=self.reference_air_pressure,
+            )
+
+    def test_different_pressure_units(self):
+        self.eta.units = cf_units.Unit("hPa")
+        self.surface_air_pressure.units = cf_units.Unit("Pa")
+        msg = "Incompatible units: eta and surface_air_pressure must have the same units."
+        with pytest.raises(ValueError, match=msg):
+            HybridLogPressureFactory(
+                eta=self.eta,
+                sigma=self.sigma,
+                surface_air_pressure=self.surface_air_pressure,
+                reference_air_pressure=self.reference_air_pressure,
+            )
+
+    def test_too_many_eta_bounds(self):
+        self.eta.nbounds = 4
+        msg = "Invalid eta coordinate: must have either 0 or 2 bounds."
+        with pytest.raises(ValueError, match=msg):
+            HybridLogPressureFactory(
+                eta=self.eta,
+                sigma=self.sigma,
+                surface_air_pressure=self.surface_air_pressure,
+                reference_air_pressure=self.reference_air_pressure,
+            )
+
+    def test_too_many_sigma_bounds(self):
+        self.sigma.nbounds = 4
+        msg = "Invalid sigma coordinate: must have either 0 or 2 bounds."
+        with pytest.raises(ValueError, match=msg):
+            HybridLogPressureFactory(
+                eta=self.eta,
+                sigma=self.sigma,
+                surface_air_pressure=self.surface_air_pressure,
+                reference_air_pressure=self.reference_air_pressure,
+            )
+
+    def test_factory_metadata(self):
+        factory = HybridLogPressureFactory(
+            eta=self.eta,
+            sigma=self.sigma,
+            surface_air_pressure=self.surface_air_pressure,
+            reference_air_pressure=self.reference_air_pressure,
+        )
+        assert factory.standard_name == "air_pressure"
+        assert factory.long_name is None
+        assert factory.var_name is None
+        assert factory.units == self.eta.units
+        assert factory.units == self.surface_air_pressure.units
+        assert factory.coord_system is None
+        assert factory.attributes == {}
+
+    def test_promote_sigma_units_unknown_to_dimensionless(self):
+        sigma = Mock(units=cf_units.Unit("unknown"), nbounds=0)
+        factory = HybridLogPressureFactory(
+            eta=self.eta,
+            sigma=sigma,
+            surface_air_pressure=self.surface_air_pressure,
+            reference_air_pressure=self.reference_air_pressure,
+        )
+        assert factory.dependencies["sigma"].units == "1"
+
+
+class Test_dependencies:
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        create_default_sample_parts(self)
+
+    def test_value(self):
+        kwargs = dict(
+            eta=self.eta,
+            sigma=self.sigma,
+            surface_air_pressure=self.surface_air_pressure,
+            reference_air_pressure=self.reference_air_pressure,
+        )
+        factory = HybridLogPressureFactory(**kwargs)
+        assert factory.dependencies == kwargs
+
+
+class Test_make_coord:
+    @staticmethod
+    def coords_dims_func(coord):
+        mapping = dict(level_pressure=(0,), sigma=(0,), surface_air_pressure=(1, 2))
+        return mapping[coord.name()]
+
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        # Create standard data objects for coord testing
+        self.eta = iris.coords.DimCoord(
+            [0.0, 1.0, 2.0], long_name="level_pressure", units="Pa"
+        )
+        self.sigma = iris.coords.DimCoord([1.0, 0.9, 0.8], long_name="sigma", units="1")
+        self.surface_air_pressure = iris.coords.AuxCoord(
+            np.arange(4).reshape(2, 2), "surface_air_pressure", units="Pa"
+        )
+
+    def test_points_only(self):
+        # Determine expected coord by manually broadcasting coord points
+        # knowing the dimension mapping.
+        eta_pts = self.eta.points[..., np.newaxis, np.newaxis]
+        sigma_pts = self.sigma.points[..., np.newaxis, np.newaxis]
+        surf_pts = self.surface_air_pressure.points[np.newaxis, ...]
+        ref_pts = self.surface_air_pressure.points[np.newaxis, ...]
+        expected_points = ref_pts * eta_pts * ( surf_pts / ref_pts ) **sigma_pts
+        expected_coord = iris.coords.AuxCoord(
+            expected_points, standard_name="air_pressure", units="Pa"
+        )
+        factory = HybridLogPressureFactory(
+            eta=self.eta,
+            sigma=self.sigma,
+            surface_air_pressure=self.surface_air_pressure,
+            reference_air_pressure=self.reference_air_pressure,
+        )
+        derived_coord = factory.make_coord(self.coords_dims_func)
+        assert derived_coord == expected_coord
+
+    def test_none_eta(self):
+        eta_pts = 0
+        sigma_pts = self.sigma.points[..., np.newaxis, np.newaxis]
+        surf_pts = self.surface_air_pressure.points[np.newaxis, ...]
+        ref_pts = self.surface_air_pressure.points[np.newaxis, ...]
+        expected_points = ref_pts * eta_pts * ( surf_pts / ref_pts ) **sigma_pts
+        expected_coord = iris.coords.AuxCoord(
+            expected_points, standard_name="air_pressure", units="Pa"
+        )
+        factory = HybridLogPressureFactory(
+            sigma=self.sigma,
+            surface_air_pressure=self.surface_air_pressure,
+            reference_air_pressure=self.reference_air_pressure,
+        )
+        derived_coord = factory.make_coord(self.coords_dims_func)
+        assert derived_coord == expected_coord
+
+    def test_none_sigma(self):
+        eta_pts = self.eta.points[..., np.newaxis, np.newaxis]
+        sigma_pts = 0
+        surf_pts = self.surface_air_pressure.points[np.newaxis, ...]
+        ref_pts = self.surface_air_pressure.points[np.newaxis, ...]
+        expected_points = ref_pts * eta_pts * ( surf_pts / ref_pts ) **sigma_pts
+        expected_coord = iris.coords.AuxCoord(
+            expected_points, standard_name="air_pressure", units="Pa"
+        )
+        factory = HybridLogPressureFactory(
+            eta=self.eta,
+            surface_air_pressure=self.surface_air_pressure,
+            reference_air_pressure=self.reference_air_pressure,
+        )
+        derived_coord = factory.make_coord(self.coords_dims_func)
+        assert derived_coord == expected_coord
+
+    # def test_none_surface_air_pressure(self):
+    #     # Note absence of broadcasting as multidimensional coord
+    #     # is not present.
+    #     expected_points = self.eta.points
+    #     expected_coord = iris.coords.AuxCoord(
+    #         expected_points, standard_name="air_pressure", units="Pa"
+    #     )
+    #     factory = HybridLogPressureFactory(eta=self.eta, sigma=self.sigma)
+    #     derived_coord = factory.make_coord(self.coords_dims_func)
+    #     assert derived_coord == expected_coord
+
+    def test_with_bounds(self):
+        self.eta.guess_bounds(0)
+        self.sigma.guess_bounds(0.5)
+        # Determine expected coord by manually broadcasting coord points
+        # and bounds based on the dimension mapping.
+        eta_pts = self.eta.points[..., np.newaxis, np.newaxis]
+        sigma_pts = self.sigma.points[..., np.newaxis, np.newaxis]
+        surf_pts = self.surface_air_pressure.points[np.newaxis, ...]
+        ref_pts = self.reference_air_pressure.points[np.newaxis, ...]
+        expected_points = ref_pts * eta_pts * ( surf_pts / ref_pts ) **sigma_pts
+        eta_vals = self.eta.bounds.reshape(3, 1, 1, 2)
+        sigma_vals = self.sigma.bounds.reshape(3, 1, 1, 2)
+        surf_vals = self.surface_air_pressure.points.reshape(1, 2, 2, 1)
+        ref_vals = self.reference_air_pressure.bounds.reshape(3, 1, 1, 2)
+        expected_bounds = ref_vals * eta_vals * ( surf_vals / ref_vals ) **sigma_vals
+        expected_coord = iris.coords.AuxCoord(
+            expected_points,
+            standard_name="air_pressure",
+            units="Pa",
+            bounds=expected_bounds,
+        )
+        factory = HybridLogPressureFactory(
+            eta=self.eta,
+            sigma=self.sigma,
+            surface_air_pressure=self.surface_air_pressure,
+            reference_air_pressure=self.reference_air_pressure,
+        )
+        derived_coord = factory.make_coord(self.coords_dims_func)
+        assert derived_coord == expected_coord
+
+
+class Test_update:
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        create_default_sample_parts(self)
+
+    def test_good_eta(self):
+        new_eta_coord = Mock(units=cf_units.Unit("Pa"), nbounds=0)
+        self.factory.update(self.eta, new_eta_coord)
+        assert self.factory.eta is new_eta_coord
+
+    def test_bad_eta(self):
+        new_eta_coord = Mock(units=cf_units.Unit("1"), nbounds=0)
+        msg = "Failed to update dependencies. Incompatible units: eta and surface_air_pressure must have the same units."
+        with pytest.raises(ValueError, match=msg):
+            self.factory.update(self.eta, new_eta_coord)
+
+    def test_alternative_bad_eta(self):
+        new_eta_coord = Mock(units=cf_units.Unit("Pa"), nbounds=4)
+        msg = "Failed to update dependencies. Invalid eta coordinate: must have either 0 or 2 bounds."
+        with pytest.raises(ValueError, match=msg):
+            self.factory.update(self.eta, new_eta_coord)
+
+    def test_good_surface_air_pressure(self):
+        new_surface_p_coord = Mock(units=cf_units.Unit("Pa"), nbounds=0)
+        self.factory.update(self.surface_air_pressure, new_surface_p_coord)
+        assert self.factory.surface_air_pressure is new_surface_p_coord
+
+    def test_bad_surface_air_pressure(self):
+        new_surface_p_coord = Mock(units=cf_units.Unit("km"), nbounds=0)
+        msg = "Failed to update dependencies. Incompatible units: eta and surface_air_pressure must have the same units."
+        with pytest.raises(ValueError, match=msg):
+            self.factory.update(self.surface_air_pressure, new_surface_p_coord)
+
+    def test_non_dependency(self):
+        old_coord = Mock()
+        new_coord = Mock()
+        orig_dependencies = self.factory.dependencies
+        self.factory.update(old_coord, new_coord)
+        assert self.factory.dependencies == orig_dependencies
+
+    def test_none_eta(self):
+        self.factory.update(self.eta, None)
+        assert self.factory.eta is None
+
+    def test_none_sigma(self):
+        self.factory.update(self.sigma, None)
+        assert self.factory.sigma is None
+
+    def test_insufficient_coords(self):
+        self.factory.update(self.eta, None)
+        msg = "Failed to update dependencies. Unable to construct hybrid pressure coordinate factory due to insufficient source coordinates."
+        with pytest.raises(ValueError, match=msg):
+            self.factory.update(self.surface_air_pressure, None)

--- a/lib/iris/tests/unit/aux_factory/test_HybridLogPressureFactory.py
+++ b/lib/iris/tests/unit/aux_factory/test_HybridLogPressureFactory.py
@@ -41,7 +41,10 @@ class Test___init__:
             HybridLogPressureFactory()
         with pytest.raises(ValueError, match=msg):
             HybridLogPressureFactory(
-                eta=None, sigma=self.sigma, surface_air_pressure=None, reference_air_pressure=None
+                eta=None,
+                sigma=self.sigma,
+                surface_air_pressure=None,
+                reference_air_pressure=None,
             )
         with pytest.raises(ValueError, match=msg):
             HybridLogPressureFactory(
@@ -53,7 +56,9 @@ class Test___init__:
 
     def test_incompatible_eta_units(self):
         self.eta.units = cf_units.Unit("m")
-        msg = "Incompatible units: eta and surface_air_pressure must have the same units."
+        msg = (
+            "Incompatible units: eta and surface_air_pressure must have the same units."
+        )
         with pytest.raises(ValueError, match=msg):
             HybridLogPressureFactory(
                 eta=self.eta,
@@ -75,7 +80,9 @@ class Test___init__:
 
     def test_incompatible_surface_air_pressure_units(self):
         self.surface_air_pressure.units = cf_units.Unit("unknown")
-        msg = "Incompatible units: eta and surface_air_pressure must have the same units."
+        msg = (
+            "Incompatible units: eta and surface_air_pressure must have the same units."
+        )
         with pytest.raises(ValueError, match=msg):
             HybridLogPressureFactory(
                 eta=self.eta,
@@ -87,7 +94,9 @@ class Test___init__:
     def test_different_pressure_units(self):
         self.eta.units = cf_units.Unit("hPa")
         self.surface_air_pressure.units = cf_units.Unit("Pa")
-        msg = "Incompatible units: eta and surface_air_pressure must have the same units."
+        msg = (
+            "Incompatible units: eta and surface_air_pressure must have the same units."
+        )
         with pytest.raises(ValueError, match=msg):
             HybridLogPressureFactory(
                 eta=self.eta,
@@ -184,7 +193,7 @@ class Test_make_coord:
         sigma_pts = self.sigma.points[..., np.newaxis, np.newaxis]
         surf_pts = self.surface_air_pressure.points[np.newaxis, ...]
         ref_pts = self.surface_air_pressure.points[np.newaxis, ...]
-        expected_points = ref_pts * eta_pts * ( surf_pts / ref_pts ) **sigma_pts
+        expected_points = ref_pts * eta_pts * (surf_pts / ref_pts) ** sigma_pts
         expected_coord = iris.coords.AuxCoord(
             expected_points, standard_name="air_pressure", units="Pa"
         )
@@ -202,7 +211,7 @@ class Test_make_coord:
         sigma_pts = self.sigma.points[..., np.newaxis, np.newaxis]
         surf_pts = self.surface_air_pressure.points[np.newaxis, ...]
         ref_pts = self.surface_air_pressure.points[np.newaxis, ...]
-        expected_points = ref_pts * eta_pts * ( surf_pts / ref_pts ) **sigma_pts
+        expected_points = ref_pts * eta_pts * (surf_pts / ref_pts) ** sigma_pts
         expected_coord = iris.coords.AuxCoord(
             expected_points, standard_name="air_pressure", units="Pa"
         )
@@ -219,7 +228,7 @@ class Test_make_coord:
         sigma_pts = 0
         surf_pts = self.surface_air_pressure.points[np.newaxis, ...]
         ref_pts = self.surface_air_pressure.points[np.newaxis, ...]
-        expected_points = ref_pts * eta_pts * ( surf_pts / ref_pts ) **sigma_pts
+        expected_points = ref_pts * eta_pts * (surf_pts / ref_pts) ** sigma_pts
         expected_coord = iris.coords.AuxCoord(
             expected_points, standard_name="air_pressure", units="Pa"
         )
@@ -251,12 +260,12 @@ class Test_make_coord:
         sigma_pts = self.sigma.points[..., np.newaxis, np.newaxis]
         surf_pts = self.surface_air_pressure.points[np.newaxis, ...]
         ref_pts = self.reference_air_pressure.points[np.newaxis, ...]
-        expected_points = ref_pts * eta_pts * ( surf_pts / ref_pts ) **sigma_pts
+        expected_points = ref_pts * eta_pts * (surf_pts / ref_pts) ** sigma_pts
         eta_vals = self.eta.bounds.reshape(3, 1, 1, 2)
         sigma_vals = self.sigma.bounds.reshape(3, 1, 1, 2)
         surf_vals = self.surface_air_pressure.points.reshape(1, 2, 2, 1)
         ref_vals = self.reference_air_pressure.bounds.reshape(3, 1, 1, 2)
-        expected_bounds = ref_vals * eta_vals * ( surf_vals / ref_vals ) **sigma_vals
+        expected_bounds = ref_vals * eta_vals * (surf_vals / ref_vals) ** sigma_vals
         expected_coord = iris.coords.AuxCoord(
             expected_points,
             standard_name="air_pressure",

--- a/lib/iris/tests/unit/aux_factory/test_HybridLogPressureFactory.py
+++ b/lib/iris/tests/unit/aux_factory/test_HybridLogPressureFactory.py
@@ -18,12 +18,12 @@ from iris.aux_factory import HybridLogPressureFactory
 
 
 def create_default_sample_parts(self):
-    self.eta = Mock(units=cf_units.Unit("Pa"), nbounds=0)
+    self.eta = Mock(units=cf_units.Unit("1"), nbounds=0)
     self.sigma = Mock(units=cf_units.Unit("1"), nbounds=0)
     self.surface_air_pressure = Mock(units=cf_units.Unit("Pa"), nbounds=0)
     self.reference_air_pressure = Mock(units=cf_units.Unit("Pa"), nbounds=0)
     self.factory = HybridLogPressureFactory(
-        eat=self.eta,
+        eta=self.eta,
         sigma=self.sigma,
         surface_air_pressure=self.surface_air_pressure,
         reference_air_pressure=self.reference_air_pressure,
@@ -56,9 +56,7 @@ class Test___init__:
 
     def test_incompatible_eta_units(self):
         self.eta.units = cf_units.Unit("m")
-        msg = (
-            "Incompatible units: eta and surface_air_pressure must have the same units."
-        )
+        msg = "Invalid units: eta must be dimensionless."
         with pytest.raises(ValueError, match=msg):
             HybridLogPressureFactory(
                 eta=self.eta,
@@ -81,7 +79,7 @@ class Test___init__:
     def test_incompatible_surface_air_pressure_units(self):
         self.surface_air_pressure.units = cf_units.Unit("unknown")
         msg = (
-            "Incompatible units: eta and surface_air_pressure must have the same units."
+            "Incompatible units: reference_air_pressure and surface_air_pressure must have the same units."
         )
         with pytest.raises(ValueError, match=msg):
             HybridLogPressureFactory(
@@ -92,11 +90,12 @@ class Test___init__:
             )
 
     def test_different_pressure_units(self):
-        self.eta.units = cf_units.Unit("hPa")
+        self.reference_air_pressure.units = cf_units.Unit("hPa")
         self.surface_air_pressure.units = cf_units.Unit("Pa")
         msg = (
-            "Incompatible units: eta and surface_air_pressure must have the same units."
-        )
+                "Incompatible units: reference_air_pressure and "
+                "surface_air_pressure must have the same units."
+            )
         with pytest.raises(ValueError, match=msg):
             HybridLogPressureFactory(
                 eta=self.eta,
@@ -137,7 +136,7 @@ class Test___init__:
         assert factory.standard_name == "air_pressure"
         assert factory.long_name is None
         assert factory.var_name is None
-        assert factory.units == self.eta.units
+        assert factory.units == self.reference_air_pressure.units
         assert factory.units == self.surface_air_pressure.units
         assert factory.coord_system is None
         assert factory.attributes == {}
@@ -172,18 +171,21 @@ class Test_dependencies:
 class Test_make_coord:
     @staticmethod
     def coords_dims_func(coord):
-        mapping = dict(level_pressure=(0,), sigma=(0,), surface_air_pressure=(1, 2))
+        mapping = dict(level_pressure=(0,), sigma=(0,), surface_air_pressure=(1, 2), reference_air_pressure=(0,))
         return mapping[coord.name()]
 
     @pytest.fixture(autouse=True)
     def _setup(self):
         # Create standard data objects for coord testing
         self.eta = iris.coords.DimCoord(
-            [0.0, 1.0, 2.0], long_name="level_pressure", units="Pa"
+            [0.0, 1.0, 2.0], long_name="level_pressure", units="1"
         )
         self.sigma = iris.coords.DimCoord([1.0, 0.9, 0.8], long_name="sigma", units="1")
         self.surface_air_pressure = iris.coords.AuxCoord(
             np.arange(4).reshape(2, 2), "surface_air_pressure", units="Pa"
+        )
+        self.reference_air_pressure = iris.coords.AuxCoord(
+            np.array(1), long_name="reference_air_pressure", units="Pa"
         )
 
     def test_points_only(self):
@@ -192,7 +194,7 @@ class Test_make_coord:
         eta_pts = self.eta.points[..., np.newaxis, np.newaxis]
         sigma_pts = self.sigma.points[..., np.newaxis, np.newaxis]
         surf_pts = self.surface_air_pressure.points[np.newaxis, ...]
-        ref_pts = self.surface_air_pressure.points[np.newaxis, ...]
+        ref_pts = self.reference_air_pressure.points
         expected_points = ref_pts * eta_pts * (surf_pts / ref_pts) ** sigma_pts
         expected_coord = iris.coords.AuxCoord(
             expected_points, standard_name="air_pressure", units="Pa"
@@ -206,50 +208,17 @@ class Test_make_coord:
         derived_coord = factory.make_coord(self.coords_dims_func)
         assert derived_coord == expected_coord
 
-    def test_none_eta(self):
-        eta_pts = 0
-        sigma_pts = self.sigma.points[..., np.newaxis, np.newaxis]
-        surf_pts = self.surface_air_pressure.points[np.newaxis, ...]
-        ref_pts = self.surface_air_pressure.points[np.newaxis, ...]
-        expected_points = ref_pts * eta_pts * (surf_pts / ref_pts) ** sigma_pts
+    def test_none_surface_air_pressure(self):
+        # Note absence of broadcasting as multidimensional coord
+        # is not present.
+        expected_points = self.eta.points * 0
         expected_coord = iris.coords.AuxCoord(
             expected_points, standard_name="air_pressure", units="Pa"
         )
-        factory = HybridLogPressureFactory(
-            sigma=self.sigma,
-            surface_air_pressure=self.surface_air_pressure,
-            reference_air_pressure=self.reference_air_pressure,
-        )
+        factory = HybridLogPressureFactory(eta=self.eta, sigma=self.sigma, reference_air_pressure=self.reference_air_pressure)
         derived_coord = factory.make_coord(self.coords_dims_func)
-        assert derived_coord == expected_coord
 
-    def test_none_sigma(self):
-        eta_pts = self.eta.points[..., np.newaxis, np.newaxis]
-        sigma_pts = 0
-        surf_pts = self.surface_air_pressure.points[np.newaxis, ...]
-        ref_pts = self.surface_air_pressure.points[np.newaxis, ...]
-        expected_points = ref_pts * eta_pts * (surf_pts / ref_pts) ** sigma_pts
-        expected_coord = iris.coords.AuxCoord(
-            expected_points, standard_name="air_pressure", units="Pa"
-        )
-        factory = HybridLogPressureFactory(
-            eta=self.eta,
-            surface_air_pressure=self.surface_air_pressure,
-            reference_air_pressure=self.reference_air_pressure,
-        )
-        derived_coord = factory.make_coord(self.coords_dims_func)
         assert derived_coord == expected_coord
-
-    # def test_none_surface_air_pressure(self):
-    #     # Note absence of broadcasting as multidimensional coord
-    #     # is not present.
-    #     expected_points = self.eta.points
-    #     expected_coord = iris.coords.AuxCoord(
-    #         expected_points, standard_name="air_pressure", units="Pa"
-    #     )
-    #     factory = HybridLogPressureFactory(eta=self.eta, sigma=self.sigma)
-    #     derived_coord = factory.make_coord(self.coords_dims_func)
-    #     assert derived_coord == expected_coord
 
     def test_with_bounds(self):
         self.eta.guess_bounds(0)
@@ -259,12 +228,12 @@ class Test_make_coord:
         eta_pts = self.eta.points[..., np.newaxis, np.newaxis]
         sigma_pts = self.sigma.points[..., np.newaxis, np.newaxis]
         surf_pts = self.surface_air_pressure.points[np.newaxis, ...]
-        ref_pts = self.reference_air_pressure.points[np.newaxis, ...]
+        ref_pts = self.reference_air_pressure.points
         expected_points = ref_pts * eta_pts * (surf_pts / ref_pts) ** sigma_pts
         eta_vals = self.eta.bounds.reshape(3, 1, 1, 2)
         sigma_vals = self.sigma.bounds.reshape(3, 1, 1, 2)
         surf_vals = self.surface_air_pressure.points.reshape(1, 2, 2, 1)
-        ref_vals = self.reference_air_pressure.bounds.reshape(3, 1, 1, 2)
+        ref_vals = self.reference_air_pressure.points
         expected_bounds = ref_vals * eta_vals * (surf_vals / ref_vals) ** sigma_vals
         expected_coord = iris.coords.AuxCoord(
             expected_points,
@@ -287,16 +256,16 @@ class Test_update:
     def _setup(self):
         create_default_sample_parts(self)
 
-    def test_good_eta(self):
-        new_eta_coord = Mock(units=cf_units.Unit("Pa"), nbounds=0)
-        self.factory.update(self.eta, new_eta_coord)
-        assert self.factory.eta is new_eta_coord
+    def test_good_reference_air_pressure(self):
+        new_ref_coord = Mock(units=cf_units.Unit("Pa"), nbounds=0)
+        self.factory.update(self.reference_air_pressure, new_ref_coord)
+        assert self.factory.reference_air_pressure is new_ref_coord
 
-    def test_bad_eta(self):
-        new_eta_coord = Mock(units=cf_units.Unit("1"), nbounds=0)
-        msg = "Failed to update dependencies. Incompatible units: eta and surface_air_pressure must have the same units."
+    def test_bad_reference_air_pressure(self):
+        new_ref_coord = Mock(units=cf_units.Unit("1"), nbounds=0)
+        msg = "Failed to update dependencies. Incompatible units: reference_air_pressure and surface_air_pressure must have the same units."
         with pytest.raises(ValueError, match=msg):
-            self.factory.update(self.eta, new_eta_coord)
+            self.factory.update(self.reference_air_pressure, new_ref_coord)
 
     def test_alternative_bad_eta(self):
         new_eta_coord = Mock(units=cf_units.Unit("Pa"), nbounds=4)
@@ -311,7 +280,7 @@ class Test_update:
 
     def test_bad_surface_air_pressure(self):
         new_surface_p_coord = Mock(units=cf_units.Unit("km"), nbounds=0)
-        msg = "Failed to update dependencies. Incompatible units: eta and surface_air_pressure must have the same units."
+        msg = "Failed to update dependencies. Incompatible units: reference_air_pressure and surface_air_pressure must have the same units."
         with pytest.raises(ValueError, match=msg):
             self.factory.update(self.surface_air_pressure, new_surface_p_coord)
 
@@ -323,15 +292,17 @@ class Test_update:
         assert self.factory.dependencies == orig_dependencies
 
     def test_none_eta(self):
-        self.factory.update(self.eta, None)
-        assert self.factory.eta is None
+        msg = "Failed to update dependencies. Unable to construct hybrid log-pressure coordinate factory due to insufficient source coordinates."
+        with pytest.raises(ValueError, match=msg):
+            self.factory.update(self.eta, None)
 
     def test_none_sigma(self):
-        self.factory.update(self.sigma, None)
-        assert self.factory.sigma is None
+        msg = "Failed to update dependencies. Unable to construct hybrid log-pressure coordinate factory due to insufficient source coordinates."
+        with pytest.raises(ValueError, match=msg):
+            self.factory.update(self.sigma, None)
 
     def test_insufficient_coords(self):
-        self.factory.update(self.eta, None)
-        msg = "Failed to update dependencies. Unable to construct hybrid pressure coordinate factory due to insufficient source coordinates."
+        self.factory.update(self.surface_air_pressure, None)
+        msg = "Failed to update dependencies. Unable to construct hybrid log-pressure coordinate factory due to insufficient source coordinates."
         with pytest.raises(ValueError, match=msg):
-            self.factory.update(self.surface_air_pressure, None)
+            self.factory.update(self.reference_air_pressure, None)


### PR DESCRIPTION
## Description

Following the addition of a new parametric vertical coordinate in the CF conventions (see PR https://github.com/WCRP-CMIP/Essential-Model-Documentation/pull/396, docs https://cfconventions.org/cf-conventions/cf-conventions.html#_atmosphere_hybrid_sigma_log_pressure_coordinate) for `atmosphere_hybrid_sigma_ln_pressure_coordinate`, a new `iris.aux_factory` is required to support models with these coordinates.

Please note: This is my first PR to iris, any assistance or helpful feedback is appreciated. I work with the ECCC CCCma on the development of the CanESM models, where CanESM6-0-MR for CMIP7 is one of the datasets that uses `atmosphere_hybrid_sigma_log_pressure_coordinate`.

The new class, and related modifications, are based on the implementation of the existing `HybridPressureFactory`. 

## Checklist

> [!IMPORTANT]
> **The Iris core developers are here to help!** If anything below is unclear, just post a comment asking for help 😊

- [x] Included a [**What's New**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/documenting/whats_new_contributions.html) entry
- [ ] Incorporated [**type hints**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_code_formatting.html#type-hinting) in any changed code
- [x] Checked if [**tests**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_tests.html) need updating
- [ ] Checked if [**benchmarks**](../benchmarks/README.md#writing-benchmarks) need updating
- [x] Checked if **documentation** needs updating
  - [Docstrings](https://scitools-iris.readthedocs.io/en/latest/developers_guide/documenting/docstrings.html) (we love code examples!)
  - [User Manual](https://scitools-iris.readthedocs.io/en/latest/user_manual/) pages
- [x] Checked if [**dependencies**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_ci_tests.html#gha-test-env) need updating
- [ ] Confirmed that the GitHub **'checks'** on this PR are passing :white_check_mark:
  _([further reading](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_ci_tests.html))_

---
> [!TIP]
> Things you can trigger on this PR:
>
> - Add this label to trigger benchmarks: https://github.com/SciTools/iris/labels/benchmark_this
> - Visit this URL - swapping `9999` for this PR's number - to re-trigger the [CLA check](https://github.com/SciTools/.github/wiki/Contributor-Licence-Agreement):
>   `https://cla-assistant.io/check/SciTools/iris?pullRequest=9999`
