### PR TITLE
Fix TEST_DATA_DIR default behaviour

### DIFF
--- a/changelog/7257.bugfix.rst
+++ b/changelog/7257.bugfix.rst
@@ -1,0 +1,1 @@
+:user:`stephenworsley` fixed the default value for ``TEST_DATA_DIR``.

--- a/lib/iris/config.py
+++ b/lib/iris/config.py
@@ -168,7 +168,7 @@ _RESOURCE_SECTION = "Resources"
 TEST_DATA_DIR = get_dir_option(
     _RESOURCE_SECTION,
     "test_data_dir",
-    default=str(Path(__file__) / "test_data"),
+    default=str(Path(__file__).parent / "test_data"),
 )
 
 # Override the data repository if the appropriate environment variable


### PR DESCRIPTION
Bug with TEST_DATA_DIR seems to have been introduced with #7087. This PR reverts to the previous behaviour.