### PR TITLE
Compatibility with python-xxhash v4.0

### DIFF
--- a/docs/src/whatsnew/3.16/3.16.rst
+++ b/docs/src/whatsnew/3.16/3.16.rst
@@ -160,7 +160,7 @@ v3.16 (13 Aug 2026)
 
 - :fa:`code-pull-request` :pull:`7223`: :user:`trexfeathers` updated Iris to be compatible with Matplotlib version 3.11.
 
-- :fa:`code-pull-request` :pull:`7262`: :user:`trexfeathers` updated Iris' metadata handling to be compatible with python-xxhas version 4.0 .
+- :fa:`code-pull-request` :pull:`7262`: :user:`trexfeathers` updated Iris' metadata handling to be compatible with python-xxhash version 4.0 .
 
 
 

--- a/docs/src/whatsnew/3.16/3.16.rst
+++ b/docs/src/whatsnew/3.16/3.16.rst
@@ -160,6 +160,8 @@ v3.16 (13 Aug 2026)
 
 - :fa:`code-pull-request` :pull:`7223`: :user:`trexfeathers` updated Iris to be compatible with Matplotlib version 3.11.
 
+- :fa:`code-pull-request` :pull:`7262`: :user:`trexfeathers` updated Iris' metadata handling to be compatible with python-xxhas version 4.0 .
+
 
 
 📚 Documentation

--- a/lib/iris/common/metadata.py
+++ b/lib/iris/common/metadata.py
@@ -96,6 +96,10 @@ def hexdigest(item):
         parts = (item.shape, xxh64_hexdigest(item))
         item = str(parts)
 
+    # xxhash 4.0+: str is no longer accepted; encode to bytes first.
+    if isinstance(item, str):
+        item = item.encode()
+
     try:
         # Calculate single-shot hash to avoid allocating state on the heap
         result = xxh64_hexdigest(item)
@@ -104,7 +108,7 @@ def hexdigest(item):
         # string representation of the provided item instead, but
         # also fold in the object type...
         parts = (type(item), item)
-        result = xxh64_hexdigest(str(parts))
+        result = xxh64_hexdigest(str(parts).encode())
 
     return result
 

--- a/lib/iris/tests/unit/common/metadata/test_hexdigest.py
+++ b/lib/iris/tests/unit/common/metadata/test_hexdigest.py
@@ -21,7 +21,7 @@ class TestBytesLikeObject:
     @staticmethod
     def _ndarray(value):
         parts = str((value.shape, xxh64_hexdigest(value)))
-        return xxh64_hexdigest(parts)
+        return xxh64_hexdigest(parts.encode())
 
     @staticmethod
     def _masked(value):
@@ -32,11 +32,11 @@ class TestBytesLikeObject:
                 xxh64_hexdigest(value.mask),
             )
         )
-        return xxh64_hexdigest(parts)
+        return xxh64_hexdigest(parts.encode())
 
     def test_string(self):
         value = "hello world"
-        self.hasher.update(value)
+        self.hasher.update(value.encode())
         expected = self.hasher.hexdigest()
         assert hexdigest(value) == expected
 
@@ -111,7 +111,7 @@ class TestBytesLikeObject:
 class TestNotBytesLikeObject:
     def _expected(self, value):
         parts = str((type(value), value))
-        return xxh64_hexdigest(parts)
+        return xxh64_hexdigest(parts.encode())
 
     def test_int(self):
         value = 123


### PR DESCRIPTION
## Description

Closes #7251. This will not show up in our CI (conda-based) until https://github.com/conda-forge/python-xxhash-feedstock/pull/46 is merged. But I have tested locally.

Targeting `v3.16.x` since this is planned to be issued as part of a patch release.

## Checklist

> [!IMPORTANT]
> **The Iris core developers are here to help!** If anything below is unclear, just post a comment asking for help 😊

- [x] Included a [**What's New**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/documenting/whats_new_contributions.html) entry
- [x] Incorporated [**type hints**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_code_formatting.html#type-hinting) in any changed code
- [x] Checked if [**tests**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_tests.html) need updating
- [x] Checked if [**benchmarks**](../benchmarks/README.md#writing-benchmarks) need updating
- [x] Checked if **documentation** needs updating
  - [Docstrings](https://scitools-iris.readthedocs.io/en/latest/developers_guide/documenting/docstrings.html) (we love code examples!)
  - [User Manual](https://scitools-iris.readthedocs.io/en/latest/user_manual/) pages
- [x] Checked if [**dependencies**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_ci_tests.html#gha-test-env) need updating
- [x] Confirmed that the GitHub **'checks'** on this PR are passing :white_check_mark:
  _([further reading](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_ci_tests.html))_

---
> [!TIP]
> Things you can trigger on this PR:
>
> - Add this label to trigger benchmarks: https://github.com/SciTools/iris/labels/benchmark_this
> - Visit this URL - swapping `9999` for this PR's number - to re-trigger the [CLA check](https://github.com/SciTools/.github/wiki/Contributor-Licence-Agreement):
>   `https://cla-assistant.io/check/SciTools/iris?pullRequest=9999`
