### PR TITLE
Add PCHIP interpolation

### DIFF
--- a/docs/src/user_manual/tutorial/interpolation_and_regridding.rst
+++ b/docs/src/user_manual/tutorial/interpolation_and_regridding.rst
@@ -27,8 +27,9 @@ In Iris we refer to the available types of interpolation and regridding as
 `schemes`. The following are the interpolation schemes that are currently
 available in Iris:
 
-* linear interpolation (:class:`iris.analysis.Linear`), and
-* nearest-neighbour interpolation (:class:`iris.analysis.Nearest`).
+* linear interpolation (:class:`iris.analysis.Linear`),
+* nearest-neighbour interpolation (:class:`iris.analysis.Nearest`), and
+* pchip interpolation (:class:`iris.analysis.Pchip`).
 
 The following are the regridding schemes that are currently available in Iris:
 

--- a/lib/iris/analysis/__init__.py
+++ b/lib/iris/analysis/__init__.py
@@ -84,6 +84,7 @@ __all__ = (
     "PERCENTILE",
     "PROPORTION",
     "PercentileAggregator",
+    "Pchip",
     "PointInCell",
     "RMS",
     "STD_DEV",
@@ -2974,6 +2975,98 @@ class Nearest:
         return RectilinearRegridder(
             src_grid, target_grid, "nearest", self.extrapolation_mode
         )
+
+
+class Pchip:
+    """Describe the PCHIP interpolation scheme.
+
+    Describes the Piecewise Cubic Hermite Interpolating Polynomial (PCHIP)
+    interpolation scheme, for use with :meth:`iris.cube.Cube.interpolate()`.
+
+    This is a monotonic cubic interpolation method: unlike
+    :class:`Linear`, it does not overshoot the source data values, so is
+    well suited to interpolating over coordinates such as model levels or
+    depths, where values commonly must remain within physically
+    meaningful bounds.
+
+    .. note::
+        Currently only supports interpolation, not regridding.
+
+    """
+
+    def __init__(self, extrapolation_mode="extrapolate"):
+        """Pchip interpolation scheme.
+
+        Suitable for interpolating over one or more orthogonal coordinates.
+
+        Parameters
+        ----------
+        extrapolation_mode : str, default="extrapolate"
+            Must be one of the following strings:
+
+            * 'extrapolate' - The extrapolation points will be calculated
+              by extending the gradient of the closest polynomial piece.
+            * 'nan' - The extrapolation points will be be set to NaN.
+            * 'error' - A ValueError exception will be raised, notifying an
+              attempt to extrapolate.
+            * 'mask' - The extrapolation points will always be masked, even
+              if the source data is not a MaskedArray.
+            * 'nanmask' - If the source data is a MaskedArray the
+              extrapolation points will be masked. Otherwise they will be
+              set to NaN.
+            * The default mode of extrapolation is 'extrapolate'.
+
+        """
+        if extrapolation_mode not in EXTRAPOLATION_MODES:
+            msg = "Extrapolation mode {!r} not supported."
+            raise ValueError(msg.format(extrapolation_mode))
+        self.extrapolation_mode = extrapolation_mode
+
+    def __repr__(self):
+        return "Pchip({!r})".format(self.extrapolation_mode)
+
+    def interpolator(self, cube, coords):
+        """Create a pchip interpolator to perform interpolation.
+
+        Create a PCHIP interpolator to perform interpolation over the
+        given :class:`~iris.cube.Cube` specified by the dimensions of
+        the given coordinates.
+
+        Typically you should use :meth:`iris.cube.Cube.interpolate` for
+        interpolating a cube.
+
+        Parameters
+        ----------
+        cube : :class:`iris.cube.Cube`
+            The source :class:`iris.cube.Cube` to be interpolated.
+        coords : :class:`iris.cube.Cube`
+            The names or coordinate instances that are to be
+            interpolated over.
+
+        Returns
+        -------
+        A callable with the interface: ``callable(sample_points, collapse_scalar=True)``
+            Where `sample_points` is a sequence containing an array of values
+            for each of the coordinates passed to this method, and
+            ``collapse_scalar`` determines whether to remove length one
+            dimensions in the result cube caused by scalar values in
+            ``sample_points``.
+
+            The N arrays of values within ``sample_points`` will be used to
+            create an N-d grid of points that will then be sampled (rather than
+            just N points)
+
+            The values for coordinates that correspond to date/times
+            may optionally be supplied as datetime.datetime or
+            cftime.datetime instances.
+
+            For example, for the callable returned by:
+            ``Pchip().interpolator(cube, ['latitude', 'longitude'])``,
+            sample_points must have the form
+            ``[new_lat_values, new_lon_values]``.
+
+        """
+        return RectilinearInterpolator(cube, coords, "pchip", self.extrapolation_mode)
 
 
 class UnstructuredNearest:

--- a/lib/iris/analysis/_interpolation.py
+++ b/lib/iris/analysis/_interpolation.py
@@ -175,10 +175,11 @@ def _interpolated_dtype(dtype, method):
 
 
 class RectilinearInterpolator:
-    """Provide support for performing nearest-neighbour or linear interpolation.
+    """Provide support for performing nearest-neighbour, linear or pchip interpolation.
 
-    This class provides support for performing nearest-neighbour or
-    linear interpolation over one or more orthogonal dimensions.
+    This class provides support for performing nearest-neighbour,
+    linear or pchip (Piecewise Cubic Hermite Interpolating Polynomial)
+    interpolation over one or more orthogonal dimensions.
 
     """
 
@@ -193,14 +194,15 @@ class RectilinearInterpolator:
             The names or coordinate instances which are to be
             interpolated over.
         method :
-            Either 'linear' or 'nearest'.
+            One of 'linear', 'nearest' or 'pchip'.
         extrapolation_mode : str
             Must be one of the following strings:
 
             * 'extrapolate' - The extrapolation points will be calculated
               according to the method. The 'linear' method extends the
               gradient of the closest two points. The 'nearest' method
-              uses the value of the closest point.
+              uses the value of the closest point. The 'pchip' method
+              extends the gradient of the nearest polynomial piece.
             * 'nan' - The extrapolation points will be be set to NaN.
             * 'error' - A ValueError exception will be raised, notifying an
               attempt to extrapolate.
@@ -216,8 +218,8 @@ class RectilinearInterpolator:
         self._src_cube = src_cube.copy()
         # Coordinates defining the dimensions to be interpolated.
         self._src_coords = [self._src_cube.coord(coord) for coord in coords]
-        # Whether to use linear or nearest-neighbour interpolation.
-        if method not in ("linear", "nearest"):
+        # Whether to use linear, nearest-neighbour or pchip interpolation.
+        if method not in ("linear", "nearest", "pchip"):
             msg = "Interpolation method {!r} not supported".format(method)
             raise ValueError(msg)
         self._method = method
@@ -341,18 +343,37 @@ class RectilinearInterpolator:
 
         mode = EXTRAPOLATION_MODES[extrapolation_mode]
         _data = np.ma.getdata(data)
-        # NB. The constructor of the _RegularGridInterpolator class does
-        # some unnecessary checks on the fill_value parameter,
-        # so we set it afterwards instead. Sneaky. ;-)
-        interpolator = _RegularGridInterpolator(
-            src_points,
-            _data,
-            method=method,
-            bounds_error=mode.bounds_error,
-            fill_value=None,
-        )
-        interpolator.fill_value = mode.fill_value
-        result = interpolator(interp_points)
+
+        if method == "pchip":
+            # The lightweight `_RegularGridInterpolator` only supports
+            # 'linear' and 'nearest', so fall back to the full SciPy
+            # implementation, which supports 'pchip'.
+            from scipy.interpolate import RegularGridInterpolator
+
+            def _pchip_interpolator(values, fill_value):
+                return RegularGridInterpolator(
+                    src_points,
+                    values,
+                    method="pchip",
+                    bounds_error=mode.bounds_error,
+                    fill_value=fill_value,
+                )
+
+            interpolator = _pchip_interpolator(_data, mode.fill_value)
+            result = interpolator(interp_points)
+        else:
+            # NB. The constructor of the _RegularGridInterpolator class does
+            # some unnecessary checks on the fill_value parameter,
+            # so we set it afterwards instead. Sneaky. ;-)
+            interpolator = _RegularGridInterpolator(
+                src_points,
+                _data,
+                method=method,
+                bounds_error=mode.bounds_error,
+                fill_value=None,
+            )
+            interpolator.fill_value = mode.fill_value
+            result = interpolator(interp_points)
 
         # The interpolated result has now shape "points_shape + extra_shape"
         # where "points_shape" is the leading dimension of "interp_points"
@@ -370,10 +391,19 @@ class RectilinearInterpolator:
             # NB. np.ma.getmaskarray returns an array of `False` if
             # `data` is not a masked array.
             src_mask = np.ma.getmaskarray(data)
-            # Switch the extrapolation to work with mask values.
-            interpolator.fill_value = mode.mask_fill_value
-            interpolator.values = src_mask
-            mask_fraction = interpolator(interp_points)
+            if method == "pchip":
+                # The pchip spline coefficients are pre-computed from the
+                # data values at construction time, so a new interpolator
+                # must be built to evaluate the mask fraction.
+                mask_interpolator = _pchip_interpolator(
+                    src_mask.astype(_data.dtype), mode.mask_fill_value
+                )
+                mask_fraction = mask_interpolator(interp_points)
+            else:
+                # Switch the extrapolation to work with mask values.
+                interpolator.fill_value = mode.mask_fill_value
+                interpolator.values = src_mask
+                mask_fraction = interpolator(interp_points)
             new_mask = mask_fraction > 0
             result = np.ma.MaskedArray(result, new_mask)
         return result

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -5347,8 +5347,9 @@ x            -               -
             :class:`~iris.cube.Cube` to the given sample points. The
             interpolation schemes currently available in Iris are:
 
-            * :class:`iris.analysis.Linear`, and
-            * :class:`iris.analysis.Nearest`.
+            * :class:`iris.analysis.Linear`,
+            * :class:`iris.analysis.Nearest`, and
+            * :class:`iris.analysis.Pchip`.
         collapse_scalar : bool, default=True
             Whether to collapse the dimension of scalar sample points
             in the resulting cube. Default is True.

--- a/lib/iris/tests/unit/analysis/interpolation/test_RectilinearInterpolator.py
+++ b/lib/iris/tests/unit/analysis/interpolation/test_RectilinearInterpolator.py
@@ -592,3 +592,53 @@ class Test___call___time:
         _shared_utils.assert_array_equal(
             result.data, [[3, 4, 5], [3, 4, 5], [6, 7, 8], [6, 7, 8]]
         )
+
+
+class Test___call___pchip:
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        self.z = iris.coords.DimCoord(
+            np.arange(5, dtype=np.float64), long_name="z", units="1"
+        )
+        self.data = np.arange(5, dtype=np.float64) ** 2
+        cube = iris.cube.Cube(self.data, long_name="x")
+        cube.add_dim_coord(self.z, 0)
+        self.cube = cube
+        self.interpolator = RectilinearInterpolator(
+            self.cube, ["z"], "pchip", EXTRAPOLATE
+        )
+
+    def test_interpolate_at_source_points(self):
+        # At the source points, pchip should reproduce the source data.
+        result = self.interpolator([np.arange(5, dtype=np.float64)])
+        _shared_utils.assert_array_almost_equal(result.data, self.data)
+
+    def test_interpolate_between_points(self):
+        result = self.interpolator([[0.5, 1.5, 2.5, 3.5]])
+        # Values should lie strictly between their neighbouring source
+        # values, i.e. no overshoot, unlike a naive cubic interpolant.
+        assert np.all(result.data > self.data[:-1])
+        assert np.all(result.data < self.data[1:])
+
+    def test_extrapolate(self):
+        result = self.interpolator([[-1, 5]])
+        assert result.data.size == 2
+        assert np.all(np.isfinite(result.data))
+
+    def test_nan_extrapolation_mode(self):
+        interpolator = RectilinearInterpolator(self.cube, ["z"], "pchip", "nan")
+        result = interpolator([[-1, 5]])
+        assert np.all(np.isnan(result.data))
+
+    def test_masked_data(self):
+        masked_data = np.ma.masked_array(
+            self.data, mask=[False, False, True, False, False]
+        )
+        cube = iris.cube.Cube(masked_data, long_name="x")
+        cube.add_dim_coord(self.z, 0)
+        interpolator = RectilinearInterpolator(cube, ["z"], "pchip", EXTRAPOLATE)
+        result = interpolator([[0.5, 2.0, 3.5]])
+        assert np.ma.is_masked(result.data)
+        # The point requested exactly at the masked source point should
+        # remain masked in the result.
+        assert result.data.mask[1]


### PR DESCRIPTION
## Description

Exposes PCHIP (Piecewise Cubic Hermite Interpolating Polynomial) interpolation, just calling down into RegularGridInterpolator from scipy.

I'm not sure that adding into the generic interpolator is the best place for this, as I think the use case is really more for vertical interpolation. But proposing to generate discussion.

As an example, here is a vertical wind profile interpolated using linear (black) vs PCHIP (blue):

<img width="597" height="446" alt="image" src="https://github.com/user-attachments/assets/f82c85e5-0e87-44ba-9948-f3625360759f" />

The motivation is to avoid the discontinuities in (the derivative of) the wind profile.

## Checklist

> [!IMPORTANT]
> **The Iris core developers are here to help!** If anything below is unclear, just post a comment asking for help 😊

- [ ] Included a [**What's New**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/documenting/whats_new_contributions.html) entry
- [ ] Incorporated [**type hints**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_code_formatting.html#type-hinting) in any changed code
- [ ] Checked if [**tests**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_tests.html) need updating
- [ ] Checked if [**benchmarks**](../benchmarks/README.md#writing-benchmarks) need updating
- [ ] Checked if **documentation** needs updating
  - [Docstrings](https://scitools-iris.readthedocs.io/en/latest/developers_guide/documenting/docstrings.html) (we love code examples!)
  - [User Manual](https://scitools-iris.readthedocs.io/en/latest/user_manual/) pages
- [ ] Checked if [**dependencies**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_ci_tests.html#gha-test-env) need updating
- [ ] Confirmed that the GitHub **'checks'** on this PR are passing :white_check_mark:
  _([further reading](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_ci_tests.html))_
