### PR TITLE
POC: use sphinx-linkcode extension

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -24,6 +24,7 @@ import contextlib
 import datetime
 import importlib
 from importlib.metadata import version as get_version
+import inspect
 from inspect import getsource
 import ntpath
 import os
@@ -35,6 +36,10 @@ from tempfile import gettempdir
 import textwrap
 from urllib.parse import quote
 import warnings
+
+from packaging.version import parse as parse_version
+
+import iris
 
 
 # function to write  useful output to stdout, prefixing the source.
@@ -165,7 +170,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
     "sphinx.ext.todo",
-    "sphinx.ext.viewcode",
+    "sphinx.ext.linkcode",
     "sphinx_changelog",
     "sphinx_copybutton",
     "sphinx_design",
@@ -784,3 +789,43 @@ def setup(app: Sphinx) -> None:
 
     # register callback to generate gallery carousel
     app.connect("env-before-read-docs", gallery_carousel)
+
+
+# --  linkcode config ---------------------------------------------------------
+
+
+def linkcode_resolve(domain, info):
+    if domain != "py":
+        return None
+    if not info["module"]:
+        return None
+
+    modname = info["module"]
+    fullname = info["fullname"]
+
+    # Get hold of the python object
+    submod = sys.modules.get(modname)
+    if submod is None:
+        return None
+
+    obj = submod
+    for part in fullname.split("."):
+        try:
+            obj = getattr(obj, part)
+        except AttributeError:
+            return None
+
+    # Get the line numbers as a string
+    try:
+        source, lineno = inspect.getsourcelines(obj)
+    except (OSError, TypeError):
+        lineno = None
+
+    linespec = f"#L{lineno:d}-L{lineno + len(source) - 1:d}" if lineno else ""
+
+    # Get the version tag, or "main" if the version is unreleased
+    version = parse_version(iris.__version__)
+    tag = "main" if version.is_devrelease else f"v{version.public}"
+
+    filename = info["module"].replace(".", "/")
+    return f"https://github.com/SciTools/iris/tree/{tag}/lib/{filename}.py{linespec}"


### PR DESCRIPTION
## Description

Some other packages I often use (Matplotlib, Numpy, Scipy) use the [sphinx-linkcode extension](https://www.sphinx-doc.org/en/master/usage/extensions/linkcode.html) to point the `[source]` links in the API docs to the relevant code in GitHub.  I find this really useful because, once I'm studying the object's code in GitHub, it's easy to navigate to other internal code that it depends on.

I'm opening this as a proof-of-concept for how it could work in Iris, but I wonder if it would be better to put the `linkcode_resolve` function somewhere central that multiple Scitools projects could import from.  I adapted the function from [Matplotlib's version](https://github.com/matplotlib/matplotlib/blob/8808684ab63d855a32fa6cc14da6953aa5a33fd4/doc/conf.py#L784-L839).

## Checklist

> [!IMPORTANT]
> **The Iris core developers are here to help!** If anything below is unclear, just post a comment asking for help 😊

- [ ] Included a [**What's New**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/documenting/whats_new_contributions.html) entry
- [ ] Incorporated [**type hints**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_code_formatting.html#type-hinting) in any changed code
- [ ] Checked if [**tests**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_tests.html) need updating
- [ ] Checked if [**benchmarks**](../benchmarks/README.md#writing-benchmarks) need updating
- [ ] Checked if **documentation** needs updating
  - [Docstrings](https://scitools-iris.readthedocs.io/en/latest/developers_guide/documenting/docstrings.html) (we love code examples!)
  - [User Manual](https://scitools-iris.readthedocs.io/en/latest/user_manual/) pages
- [ ] Checked if [**dependencies**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_ci_tests.html#gha-test-env) need updating
- [ ] Confirmed that the GitHub **'checks'** on this PR are passing :white_check_mark:
  _([further reading](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_ci_tests.html))_

---
> [!TIP]
> Things you can trigger on this PR:
>
> - Add this label to trigger benchmarks: https://github.com/SciTools/iris/labels/benchmark_this
> - Visit this URL - swapping `9999` for this PR's number - to re-trigger the [CLA check](https://github.com/SciTools/.github/wiki/Contributor-Licence-Agreement):
>   `https://cla-assistant.io/check/SciTools/iris?pullRequest=9999`
