### PR TITLE
DOC BLD: get scipy objects inventory from their static site

### DIFF
--- a/changelog/7269.internal.rst
+++ b/changelog/7269.internal.rst
@@ -1,0 +1,1 @@
+:user:`rcomer` updated the scipy intersphinx mapping to make documentation builds more reliable.

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -313,7 +313,13 @@ intersphinx_mapping = {
     "pandas": ("https://pandas.pydata.org/docs/", None),
     "python": ("https://docs.python.org/3/", None),
     "pyvista": ("https://docs.pyvista.org/", None),
-    "scipy": ("https://docs.scipy.org/doc/scipy/", None),
+    # For scipy, get the inventory from the static site because it can be slow and
+    # sometimes times out when fetching from the docs site.
+    # https://github.com/scipy/docs.scipy.org/issues/102
+    "scipy": (
+        "https://docs.scipy.org/doc/scipy/",
+        "https://static.scipy.org/doc/scipy/objects.inv",
+    ),
 }
 
 # The name of the Pygments (syntax highlighting) style to use.


### PR DESCRIPTION
## Description

When building the docs, the fetch of the scipy object inventory sometimes times out.  I noticed this when building Iris docs locally for my last two PRs.  This PR updates the intersphinx mapping to get the inventory from scipy's static site, following the advice at https://github.com/scipy/docs.scipy.org/issues/102#issuecomment-5547829643.

## Checklist

> [!IMPORTANT]
> **The Iris core developers are here to help!** If anything below is unclear, just post a comment asking for help 😊

- [x] Included a [**What's New**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/documenting/whats_new_contributions.html) entry
- [ ] Incorporated [**type hints**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_code_formatting.html#type-hinting) in any changed code
- [x] Checked if [**tests**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_tests.html) need updating
- [x] Checked if [**benchmarks**](../benchmarks/README.md#writing-benchmarks) need updating
- [x] Checked if **documentation** needs updating
  - [Docstrings](https://scitools-iris.readthedocs.io/en/latest/developers_guide/documenting/docstrings.html) (we love code examples!)
  - [User Manual](https://scitools-iris.readthedocs.io/en/latest/user_manual/) pages
- [x] Checked if [**dependencies**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_ci_tests.html#gha-test-env) need updating
- [x] Confirmed that the GitHub **'checks'** on this PR are passing :white_check_mark:
  _([further reading](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_ci_tests.html))_

---
> [!TIP]
> Things you can trigger on this PR:
>
> - Add this label to trigger benchmarks: https://github.com/SciTools/iris/labels/benchmark_this
> - Visit this URL - swapping `9999` for this PR's number - to re-trigger the [CLA check](https://github.com/SciTools/.github/wiki/Contributor-Licence-Agreement):
>   `https://cla-assistant.io/check/SciTools/iris?pullRequest=9999`
