### PR TITLE
More robust overnight benchmark commit identification

### DIFF
--- a/.github/workflows/benchmarks_run.yml
+++ b/.github/workflows/benchmarks_run.yml
@@ -144,8 +144,10 @@ jobs:
         run: |
           first_commit=${FIRST_COMMIT}
           if [ "$first_commit" == "" ]
+          # 26 hours to cope with variability in GHA start times.
           then
-            first_commit=$(git log --after="$(date -d "1 day ago" +"%Y-%m-%d") 23:00:00" --pretty=format:"%h" | tail -n 1)
+            cutoff_utc=$(date -u -d "26 hours ago" +"%Y-%m-%dT%H:%M:%SZ")
+            first_commit=$(git rev-list --since="$cutoff_utc" --reverse HEAD | head -n 1)
           fi
 
           if [ "$first_commit" != "" ]

--- a/changelog/7271.internal.rst
+++ b/changelog/7271.internal.rst
@@ -1,0 +1,4 @@
+:user:`trexfeathers` improved robustness of overnight benchmarks in GitHub
+Actions - the start commit is the commit 26 hours ago, instead of the commit
+24 hours after 23:00 yesterday - this is to cope with variability in GHA start
+times.


### PR DESCRIPTION
## Description

To prevent problems where a delayed GHA run misses benchmarks because the definition of 'yesterday' has changed.

## Checklist

> [!IMPORTANT]
> **The Iris core developers are here to help!** If anything below is unclear, just post a comment asking for help 😊

- [x] Included a [**What's New**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/documenting/whats_new_contributions.html) entry
- [x] Incorporated [**type hints**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_code_formatting.html#type-hinting) in any changed code
- [x] Checked if [**tests**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_tests.html) need updating
- [x] Checked if [**benchmarks**](../benchmarks/README.md#writing-benchmarks) need updating
- [x] Checked if **documentation** needs updating
  - [Docstrings](https://scitools-iris.readthedocs.io/en/latest/developers_guide/documenting/docstrings.html) (we love code examples!)
  - [User Manual](https://scitools-iris.readthedocs.io/en/latest/user_manual/) pages
- [x] Checked if [**dependencies**](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_ci_tests.html#gha-test-env) need updating
- [ ] Confirmed that the GitHub **'checks'** on this PR are passing :white_check_mark:
  _([further reading](https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_ci_tests.html))_

---
> [!TIP]
> Things you can trigger on this PR:
>
> - Add this label to trigger benchmarks: https://github.com/SciTools/iris/labels/benchmark_this
> - Visit this URL - swapping `9999` for this PR's number - to re-trigger the [CLA check](https://github.com/SciTools/.github/wiki/Contributor-Licence-Agreement):
>   `https://cla-assistant.io/check/SciTools/iris?pullRequest=9999`
