### PR TITLE
[Agentic] Move array hashing into a shared _combine_common substrate

### DIFF
--- a/changelog/7276.internal.rst
+++ b/changelog/7276.internal.rst
@@ -1,0 +1,4 @@
+:user:`claude` moved the array hashing machinery out of ``iris._concatenate``
+and into a new shared ``iris._combine_common``, so that cube merge can use it
+without a circular import. This is row 1 of the merge and concatenate design
+spec roadmap, per §5.1. No behaviour is changed. (:pull:`7276`)

--- a/docs/src/developers_guide/specs/2026-09-10-merge-concatenate-design.md
+++ b/docs/src/developers_guide/specs/2026-09-10-merge-concatenate-design.md
@@ -411,7 +411,7 @@ lands. Status vocabulary: **not started** · **in progress** · **✅ complete**
 
 | # | PR | Scope (spec §) | Type | Closes | Depends on | Status |
 |---|---|---|---|---|---|---|
-| 1 | Hashing machinery → `_combine_common.py` | §5.1 — move `_concatenate.py:305-541` (~237 lines) and `tests/unit/concatenate/test_hashing.py`; names lose their underscore prefix | internal | — | — | not started |
+| 1 | Hashing machinery → `_combine_common.py` | §5.1 — move `_concatenate.py:305-541` (~237 lines) and `tests/unit/concatenate/test_hashing.py`; names lose their underscore prefix | internal | — | — | in progress ({pull}`7276`) |
 | 2 | `iris._merge.merge()` driver function | §5.3 — lift the loop out of `CubeList.merge()` (`cube.py:443-467`); `CubeList.merge` delegates, mirroring `CubeList.concatenate` | internal | — | — | not started |
 | 3 | Extend merge benchmark | §5.5 — `benchmarks/benchmarks/merge_concat.py::Merge` currently strips cell measures and ancillaries, so it cannot show the PR 4 effect | internal | — | — | not started |
 | 4 | **Hash-based comparison in merge** | §5.4 — collect arrays up front, thread `hashes` through `ProtoCube.register()` to the two `==` sites of §2.2 | performance | {issue}`7063`, {issue}`7241` | 1, 2, 3 | not started |
@@ -515,14 +515,21 @@ opened.
    unified.** They encode different questions, and forcing one type on both would
    be a rewrite wearing a refactor's clothes (§5.2). {issue}`3234` therefore
    stays open; this programme narrows it rather than closing it.
-6. **Open** (PR 1) — **Whether the moved names drop their underscore prefix.**
-   Following `_lazy_data.py` makes PR 1 a move *and* a rename, which is a
-   reasonable thing for a reviewer to object to and a cheap thing to concede. The
-   location is what matters, not the name (§8).
-7. **Open** (PR 1) — **Whether the programme proceeds past the proving tranche.**
-   §3 names review capacity as the scarce resource. PR 1 is a pure move with no
-   behaviour change and its justification is PR 4, so its reception is the signal
-   for everything after it. Nothing in PRs 5–12 is load-bearing for PRs 1–4.
+6. **Open** (PR 1, put to the reviewer in {pull}`7276`) — **Whether the moved
+   names drop their underscore prefix.** Following `_lazy_data.py` makes PR 1 a
+   move *and* a rename, which is a reasonable thing for a reviewer to object to
+   and a cheap thing to concede. The location is what matters, not the name (§8).
+   Implementation added one argument against: the unprefixed `array_id` collides
+   with eight existing local bindings — five call sites in `_concatenate.py`,
+   where the shadowing would raise `UnboundLocalError`, and three inside
+   `compute_hashes` itself, where it is inert. Every one of those renames exists
+   only to clear the unprefixed name's path, so keeping `_array_id` retires them
+   all and reduces PR 1 to a pure `git mv`.
+7. **Open** (PR 1, live in {pull}`7276`) — **Whether the programme proceeds past
+   the proving tranche.** §3 names review capacity as the scarce resource. PR 1
+   is a pure move with no behaviour change and its justification is PR 4, so its
+   reception is the signal for everything after it. Nothing in PRs 5–12 is
+   load-bearing for PRs 1–4.
 8. **Open** (PR 2) — **Whether `merge_cube()` joins the driver.** §5.3 leaves it
    alone: it builds a single ProtoCube from `self[0]` with
    `error_on_mismatch=True` and no name grouping (`cube.py:364-373`). Its error

--- a/lib/iris/_combine_common.py
+++ b/lib/iris/_combine_common.py
@@ -234,7 +234,7 @@ def compute_hashes(
         return np.issubdtype(dtype, np.bool_) or np.issubdtype(dtype, np.number)
 
     def group_key(item):
-        array_id, a = item
+        _, a = item
         if is_numerical(a.dtype):
             dtype = "numerical"
         else:
@@ -260,12 +260,12 @@ def compute_hashes(
             __, rechunked_arrays = da.core.unify_chunks(*itertools.chain(*argpairs))
         else:
             rechunked_arrays = same_dtype_arrays
-        for array_id, rechunked in zip(array_ids, rechunked_arrays):
+        for key, rechunked in zip(array_ids, rechunked_arrays):
             if isinstance(rechunked, da.Array):
                 chunks = rechunked.chunks
             else:
                 chunks = tuple((i,) for i in rechunked.shape)
-            hashes[array_id] = (hash_array(rechunked), chunks)
+            hashes[key] = (hash_array(rechunked), chunks)
 
     (hashes,) = dask.compute(hashes)
     return {k: ArrayHash(*v) for k, v in hashes.items()}

--- a/lib/iris/_combine_common.py
+++ b/lib/iris/_combine_common.py
@@ -1,0 +1,271 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the BSD license.
+# See LICENSE in the root of the repository for full licensing details.
+"""Machinery shared by cube merge and cube concatenate.
+
+This module is the substrate beneath :mod:`iris._merge` and
+:mod:`iris._concatenate`.  It deliberately imports nothing from Iris at
+runtime, so that either engine may import it without any risk of a circular
+import.  The only Iris names it requires are annotations, which are guarded
+by :data:`typing.TYPE_CHECKING`.
+
+"""
+
+from __future__ import annotations
+
+from collections import namedtuple
+import itertools
+from typing import TYPE_CHECKING, Any
+
+import dask
+import dask.array as da
+import numpy as np
+from xxhash import xxh3_64
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from iris.coords import AncillaryVariable, AuxCoord, CellMeasure, DimCoord
+
+# Restrict the names imported from this namespace.
+__all__ = ["ArrayHash", "array_id", "compute_hashes", "hash_array"]
+
+
+def hash_ndarray(a: np.ndarray) -> np.ndarray:
+    """Compute a hash from a numpy array.
+
+    Calculates a 64-bit non-cryptographic hash of the provided array, using
+    the fast ``xxhash`` hashing algorithm.
+
+    Parameters
+    ----------
+    a :
+        The array to hash.
+
+    Returns
+    -------
+    numpy.ndarray :
+        An array of shape (1,) containing the hash value.
+
+    """
+    # Include the array dtype as it is not preserved by `ndarray.tobytes()`.
+    hash = xxh3_64(f"dtype={a.dtype}".encode("utf-8"))
+
+    # Hash the bytes representing the array data.
+    hash.update(b"data=")
+    if np.ma.is_masked(a):
+        # Hash only the unmasked data
+        hash.update(a.compressed().tobytes())
+        # Hash the mask
+        hash.update(b"mask=")
+        hash.update(a.mask.tobytes())
+    else:
+        hash.update(a.tobytes())
+    return np.frombuffer(hash.digest(), dtype=np.int64)
+
+
+def hash_chunk(
+    x_chunk: np.ndarray,
+    axis: tuple[int] | None,
+    keepdims: bool,
+) -> np.ndarray:
+    """Compute a hash from a numpy array.
+
+    This function can be applied to each chunk or intermediate chunk in
+    :func:`~dask.array.reduction`. It preserves the number of input dimensions
+    to facilitate combining intermediate results into intermediate chunks.
+
+    Parameters
+    ----------
+    x_chunk :
+        The array to hash.
+    axis :
+        Unused but required by :func:`~dask.array.reduction`.
+    keepdims :
+        Unused but required by :func:`~dask.array.reduction`.
+
+    Returns
+    -------
+    numpy.ndarray :
+        An array containing the hash value.
+
+    """
+    return hash_ndarray(x_chunk).reshape((1,) * x_chunk.ndim)
+
+
+def hash_aggregate(
+    x_chunk: np.ndarray,
+    axis: tuple[int] | None,
+    keepdims: bool,
+) -> np.int64:
+    """Compute a hash from a numpy array.
+
+    This function can be applied as the final step in :func:`~dask.array.reduction`.
+
+    Parameters
+    ----------
+    x_chunk :
+        The array to hash.
+    axis :
+        Unused but required by :func:`~dask.array.reduction`.
+    keepdims :
+        Unused but required by :func:`~dask.array.reduction`.
+
+    Returns
+    -------
+    np.int64 :
+        The hash value.
+
+    """
+    (result,) = hash_ndarray(x_chunk)
+    return result
+
+
+def hash_array(a: da.Array | np.ndarray) -> np.int64:
+    """Calculate a hash representation of the provided array.
+
+    Calculates a 64-bit non-cryptographic hash of the provided array, using
+    the fast ``xxhash`` hashing algorithm.
+
+    Note that the computed hash depends on how the array is chunked.
+
+    Parameters
+    ----------
+    a :
+        The array that requires to have its hexdigest calculated.
+
+    Returns
+    -------
+    np.int64
+        The array's hash.
+
+    """
+    if isinstance(a, da.Array):
+        # Use :func:`~dask.array.reduction` to compute a hash from a Dask array.
+        #
+        # A hash of each input chunk will be computed by the `chunk` function
+        # and those hashes will be combined into one or more intermediate chunks.
+        # If there are multiple intermediate chunks, a hash for each intermediate
+        # chunk will be computed by the `combine` function and the
+        # results will be combined into a new layer of intermediate chunks. This
+        # will be repeated until only a single intermediate chunk remains.
+        # Finally, a single hash value will be computed from the last
+        # intermediate chunk by the `aggregate` function.
+        result = da.reduction(
+            a,
+            chunk=hash_chunk,
+            combine=hash_chunk,
+            aggregate=hash_aggregate,
+            keepdims=False,
+            meta=np.empty(tuple(), dtype=np.int64),
+            dtype=np.int64,
+        )
+    else:
+        result = hash_aggregate(a, None, False)
+    return result
+
+
+class ArrayHash(namedtuple("ArrayHash", ["value", "chunks"])):
+    """Container for a hash value and the chunks used when computing it.
+
+    Parameters
+    ----------
+    value : :class:`np.int64`
+        The hash value.
+    chunks : tuple
+        The chunks the array had when the hash was computed.
+    """
+
+    __slots__ = ()
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, self.__class__):
+            raise TypeError(f"Unable to compare {repr(self)} to {repr(other)}")
+
+        def shape(chunks):
+            return tuple(sum(c) for c in chunks)
+
+        if shape(self.chunks) == shape(other.chunks):
+            if self.chunks != other.chunks:
+                raise ValueError(
+                    "Unable to compare arrays with different chunks: "
+                    f"{self.chunks} != {other.chunks}"
+                )
+            result = self.value == other.value
+        else:
+            result = False
+        return result
+
+
+def array_id(
+    coord: DimCoord | AuxCoord | AncillaryVariable | CellMeasure,
+    bound: bool,
+) -> str:
+    """Get a unique key for looking up arrays associated with coordinates."""
+    return f"{id(coord)}{bound}"
+
+
+def compute_hashes(
+    arrays: Mapping[str, np.ndarray | da.Array],
+) -> dict[str, ArrayHash]:
+    """Compute hashes for the arrays that will be compared.
+
+    Two arrays are considered equal if each unmasked element compares equal
+    and the masks are equal. However, hashes depend on chunking and dtype.
+    Therefore, arrays with the same shape are rechunked so they have the same
+    chunks and arrays with numerical dtypes are cast up to the same dtype before
+    computing the hashes.
+
+    Parameters
+    ----------
+    arrays :
+        A mapping with key-array pairs.
+
+    Returns
+    -------
+    dict[str, ArrayHash] :
+        An dictionary of hashes.
+
+    """
+    hashes = {}
+
+    def is_numerical(dtype):
+        return np.issubdtype(dtype, np.bool_) or np.issubdtype(dtype, np.number)
+
+    def group_key(item):
+        array_id, a = item
+        if is_numerical(a.dtype):
+            dtype = "numerical"
+        else:
+            dtype = str(a.dtype)
+        return a.shape, dtype
+
+    sorted_arrays = sorted(arrays.items(), key=group_key)
+    for _, group_iter in itertools.groupby(sorted_arrays, key=group_key):
+        array_ids, group = zip(*group_iter)
+        # Unify dtype for numerical arrays, as the hash depends on it
+        if is_numerical(group[0].dtype):
+            dtype = np.result_type(*group)
+            same_dtype_arrays = tuple(a.astype(dtype) for a in group)
+        else:
+            same_dtype_arrays = group
+        if any(isinstance(a, da.Array) for a in same_dtype_arrays):
+            # Unify chunks as the hash depends on the chunks.
+            indices = tuple(range(group[0].ndim))
+            # Because all arrays in a group have the same shape, `indices`
+            # are the same for all of them. Providing `indices` as a tuple
+            # instead of letters is easier to do programmatically.
+            argpairs = [(a, indices) for a in same_dtype_arrays]
+            __, rechunked_arrays = da.core.unify_chunks(*itertools.chain(*argpairs))
+        else:
+            rechunked_arrays = same_dtype_arrays
+        for array_id, rechunked in zip(array_ids, rechunked_arrays):
+            if isinstance(rechunked, da.Array):
+                chunks = rechunked.chunks
+            else:
+                chunks = tuple((i,) for i in rechunked.shape)
+            hashes[array_id] = (hash_array(rechunked), chunks)
+
+    (hashes,) = dask.compute(hashes)
+    return {k: ArrayHash(*v) for k, v in hashes.items()}

--- a/lib/iris/_concatenate.py
+++ b/lib/iris/_concatenate.py
@@ -6,15 +6,12 @@
 
 from collections import namedtuple
 from collections.abc import Mapping, Sequence
-import itertools
-from typing import Any
 import warnings
 
-import dask
 import dask.array as da
 import numpy as np
-from xxhash import xxh3_64
 
+from iris._combine_common import ArrayHash, array_id, compute_hashes
 from iris._lazy_data import concatenate as concatenate_arrays
 from iris.common.metadata import hexdigest
 import iris.coords
@@ -302,245 +299,6 @@ class _CoordExtent(namedtuple("CoordExtent", ["points", "bounds"])):
     __slots__ = ()
 
 
-def _hash_ndarray(a: np.ndarray) -> np.ndarray:
-    """Compute a hash from a numpy array.
-
-    Calculates a 64-bit non-cryptographic hash of the provided array, using
-    the fast ``xxhash`` hashing algorithm.
-
-    Parameters
-    ----------
-    a :
-        The array to hash.
-
-    Returns
-    -------
-    numpy.ndarray :
-        An array of shape (1,) containing the hash value.
-
-    """
-    # Include the array dtype as it is not preserved by `ndarray.tobytes()`.
-    hash = xxh3_64(f"dtype={a.dtype}".encode("utf-8"))
-
-    # Hash the bytes representing the array data.
-    hash.update(b"data=")
-    if np.ma.is_masked(a):
-        # Hash only the unmasked data
-        hash.update(a.compressed().tobytes())
-        # Hash the mask
-        hash.update(b"mask=")
-        hash.update(a.mask.tobytes())
-    else:
-        hash.update(a.tobytes())
-    return np.frombuffer(hash.digest(), dtype=np.int64)
-
-
-def _hash_chunk(
-    x_chunk: np.ndarray,
-    axis: tuple[int] | None,
-    keepdims: bool,
-) -> np.ndarray:
-    """Compute a hash from a numpy array.
-
-    This function can be applied to each chunk or intermediate chunk in
-    :func:`~dask.array.reduction`. It preserves the number of input dimensions
-    to facilitate combining intermediate results into intermediate chunks.
-
-    Parameters
-    ----------
-    x_chunk :
-        The array to hash.
-    axis :
-        Unused but required by :func:`~dask.array.reduction`.
-    keepdims :
-        Unused but required by :func:`~dask.array.reduction`.
-
-    Returns
-    -------
-    numpy.ndarray :
-        An array containing the hash value.
-
-    """
-    return _hash_ndarray(x_chunk).reshape((1,) * x_chunk.ndim)
-
-
-def _hash_aggregate(
-    x_chunk: np.ndarray,
-    axis: tuple[int] | None,
-    keepdims: bool,
-) -> np.int64:
-    """Compute a hash from a numpy array.
-
-    This function can be applied as the final step in :func:`~dask.array.reduction`.
-
-    Parameters
-    ----------
-    x_chunk :
-        The array to hash.
-    axis :
-        Unused but required by :func:`~dask.array.reduction`.
-    keepdims :
-        Unused but required by :func:`~dask.array.reduction`.
-
-    Returns
-    -------
-    np.int64 :
-        The hash value.
-
-    """
-    (result,) = _hash_ndarray(x_chunk)
-    return result
-
-
-def _hash_array(a: da.Array | np.ndarray) -> np.int64:
-    """Calculate a hash representation of the provided array.
-
-    Calculates a 64-bit non-cryptographic hash of the provided array, using
-    the fast ``xxhash`` hashing algorithm.
-
-    Note that the computed hash depends on how the array is chunked.
-
-    Parameters
-    ----------
-    a :
-        The array that requires to have its hexdigest calculated.
-
-    Returns
-    -------
-    np.int64
-        The array's hash.
-
-    """
-    if isinstance(a, da.Array):
-        # Use :func:`~dask.array.reduction` to compute a hash from a Dask array.
-        #
-        # A hash of each input chunk will be computed by the `chunk` function
-        # and those hashes will be combined into one or more intermediate chunks.
-        # If there are multiple intermediate chunks, a hash for each intermediate
-        # chunk will be computed by the `combine` function and the
-        # results will be combined into a new layer of intermediate chunks. This
-        # will be repeated until only a single intermediate chunk remains.
-        # Finally, a single hash value will be computed from the last
-        # intermediate chunk by the `aggregate` function.
-        result = da.reduction(
-            a,
-            chunk=_hash_chunk,
-            combine=_hash_chunk,
-            aggregate=_hash_aggregate,
-            keepdims=False,
-            meta=np.empty(tuple(), dtype=np.int64),
-            dtype=np.int64,
-        )
-    else:
-        result = _hash_aggregate(a, None, False)
-    return result
-
-
-class _ArrayHash(namedtuple("ArrayHash", ["value", "chunks"])):
-    """Container for a hash value and the chunks used when computing it.
-
-    Parameters
-    ----------
-    value : :class:`np.int64`
-        The hash value.
-    chunks : tuple
-        The chunks the array had when the hash was computed.
-    """
-
-    __slots__ = ()
-
-    def __eq__(self, other: Any) -> bool:
-        if not isinstance(other, self.__class__):
-            raise TypeError(f"Unable to compare {repr(self)} to {repr(other)}")
-
-        def shape(chunks):
-            return tuple(sum(c) for c in chunks)
-
-        if shape(self.chunks) == shape(other.chunks):
-            if self.chunks != other.chunks:
-                raise ValueError(
-                    "Unable to compare arrays with different chunks: "
-                    f"{self.chunks} != {other.chunks}"
-                )
-            result = self.value == other.value
-        else:
-            result = False
-        return result
-
-
-def _array_id(
-    coord: DimCoord | AuxCoord | AncillaryVariable | CellMeasure,
-    bound: bool,
-) -> str:
-    """Get a unique key for looking up arrays associated with coordinates."""
-    return f"{id(coord)}{bound}"
-
-
-def _compute_hashes(
-    arrays: Mapping[str, np.ndarray | da.Array],
-) -> dict[str, _ArrayHash]:
-    """Compute hashes for the arrays that will be compared.
-
-    Two arrays are considered equal if each unmasked element compares equal
-    and the masks are equal. However, hashes depend on chunking and dtype.
-    Therefore, arrays with the same shape are rechunked so they have the same
-    chunks and arrays with numerical dtypes are cast up to the same dtype before
-    computing the hashes.
-
-    Parameters
-    ----------
-    arrays :
-        A mapping with key-array pairs.
-
-    Returns
-    -------
-    dict[str, _ArrayHash] :
-        An dictionary of hashes.
-
-    """
-    hashes = {}
-
-    def is_numerical(dtype):
-        return np.issubdtype(dtype, np.bool_) or np.issubdtype(dtype, np.number)
-
-    def group_key(item):
-        array_id, a = item
-        if is_numerical(a.dtype):
-            dtype = "numerical"
-        else:
-            dtype = str(a.dtype)
-        return a.shape, dtype
-
-    sorted_arrays = sorted(arrays.items(), key=group_key)
-    for _, group_iter in itertools.groupby(sorted_arrays, key=group_key):
-        array_ids, group = zip(*group_iter)
-        # Unify dtype for numerical arrays, as the hash depends on it
-        if is_numerical(group[0].dtype):
-            dtype = np.result_type(*group)
-            same_dtype_arrays = tuple(a.astype(dtype) for a in group)
-        else:
-            same_dtype_arrays = group
-        if any(isinstance(a, da.Array) for a in same_dtype_arrays):
-            # Unify chunks as the hash depends on the chunks.
-            indices = tuple(range(group[0].ndim))
-            # Because all arrays in a group have the same shape, `indices`
-            # are the same for all of them. Providing `indices` as a tuple
-            # instead of letters is easier to do programmatically.
-            argpairs = [(a, indices) for a in same_dtype_arrays]
-            __, rechunked_arrays = da.core.unify_chunks(*itertools.chain(*argpairs))
-        else:
-            rechunked_arrays = same_dtype_arrays
-        for array_id, rechunked in zip(array_ids, rechunked_arrays):
-            if isinstance(rechunked, da.Array):
-                chunks = rechunked.chunks
-            else:
-                chunks = tuple((i,) for i in rechunked.shape)
-            hashes[array_id] = (_hash_array(rechunked), chunks)
-
-    (hashes,) = dask.compute(hashes)
-    return {k: _ArrayHash(*v) for k, v in hashes.items()}
-
-
 def concatenate(
     cubes: Sequence[iris.cube.Cube],
     error_on_mismatch: bool = False,
@@ -601,14 +359,14 @@ def concatenate(
     def add_coords(cube_signature: _CubeSignature, coord_type: str) -> None:
         for coord_and_dims in getattr(cube_signature, coord_type):
             coord = coord_and_dims.coord
-            array_id = _array_id(coord, bound=False)
+            points_id = array_id(coord, bound=False)
             if isinstance(coord, (DimCoord, AuxCoord)):
-                arrays[array_id] = coord.core_points()
+                arrays[points_id] = coord.core_points()
                 if coord.has_bounds():
-                    bound_array_id = _array_id(coord, bound=True)
-                    arrays[bound_array_id] = coord.core_bounds()
+                    bounds_id = array_id(coord, bound=True)
+                    arrays[bounds_id] = coord.core_bounds()
             else:
-                arrays[array_id] = coord.core_data()
+                arrays[points_id] = coord.core_data()
 
     for cube_signature in cube_signatures:
         if check_aux_coords:
@@ -620,7 +378,7 @@ def concatenate(
         if check_ancils:
             add_coords(cube_signature, "ancillary_variables_and_dims")
 
-    hashes = _compute_hashes(arrays)
+    hashes = compute_hashes(arrays)
     msg = None
 
     # Register each cube with its appropriate proto-cube.
@@ -1138,7 +896,7 @@ class _ProtoCube:
     def register(
         self,
         cube_signature: _CubeSignature,
-        hashes: Mapping[str, _ArrayHash],
+        hashes: Mapping[str, ArrayHash],
         axis: int | None = None,
         error_on_mismatch: bool = False,
         check_aux_coords: bool = False,
@@ -1226,12 +984,12 @@ class _ProtoCube:
 
         def get_hashes(
             coord: DimCoord | AuxCoord | AncillaryVariable | CellMeasure,
-        ) -> tuple[_ArrayHash, ...]:
-            array_id = _array_id(coord, bound=False)
-            result = [hashes[array_id]]
+        ) -> tuple[ArrayHash, ...]:
+            points_id = array_id(coord, bound=False)
+            result = [hashes[points_id]]
             if isinstance(coord, (DimCoord, AuxCoord)) and coord.has_bounds():
-                bound_array_id = _array_id(coord, bound=True)
-                result.append(hashes[bound_array_id])
+                bounds_id = array_id(coord, bound=True)
+                result.append(hashes[bounds_id])
             return tuple(result)
 
         # Mapping from `_CubeSignature` attributes to human readable names.

--- a/lib/iris/tests/unit/combine_common/__init__.py
+++ b/lib/iris/tests/unit/combine_common/__init__.py
@@ -1,0 +1,5 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the BSD license.
+# See LICENSE in the root of the repository for full licensing details.
+"""Unit tests for the :mod:`iris._combine_common` module."""

--- a/lib/iris/tests/unit/combine_common/test_hashing.py
+++ b/lib/iris/tests/unit/combine_common/test_hashing.py
@@ -2,13 +2,13 @@
 #
 # This file is part of Iris and is released under the BSD license.
 # See LICENSE in the root of the repository for full licensing details.
-"""Test array hashing in :mod:`iris._concatenate`."""
+"""Test array hashing in :mod:`iris._combine_common`."""
 
 import dask.array as da
 import numpy as np
 import pytest
 
-from iris import _concatenate
+from iris import _combine_common
 from iris.tests.unit.util.test_array_equal import TEST_CASES
 from iris.util import array_equal
 
@@ -73,7 +73,7 @@ from iris.util import array_equal
     ],
 )
 def test_compute_hashes(a, b, eq):
-    hashes = _concatenate._compute_hashes({"a": a, "b": b})
+    hashes = _combine_common.compute_hashes({"a": a, "b": b})
     assert eq == (hashes["a"] == hashes["b"])
 
 
@@ -87,20 +87,20 @@ def test_compute_hashes(a, b, eq):
 )
 def test_compute_hashes_vs_array_equal(a, b):
     """Test that hashing give the same answer as `array_equal(withnans=True)`."""
-    hashes = _concatenate._compute_hashes({"a": a, "b": b})
+    hashes = _combine_common.compute_hashes({"a": a, "b": b})
     assert array_equal(a, b, withnans=True) == (hashes["a"] == hashes["b"])
 
 
 def test_arrayhash_equal_incompatible_chunks_raises():
-    hash1 = _concatenate._ArrayHash(1, chunks=((1, 1),))
-    hash2 = _concatenate._ArrayHash(1, chunks=((2,),))
+    hash1 = _combine_common.ArrayHash(1, chunks=((1, 1),))
+    hash2 = _combine_common.ArrayHash(1, chunks=((2,),))
     msg = r"Unable to compare arrays with different chunks.*"
     with pytest.raises(ValueError, match=msg):
         hash1 == hash2
 
 
 def test_arrayhash_equal_incompatible_type_raises():
-    hash = _concatenate._ArrayHash(1, chunks=(1, 1))
+    hash = _combine_common.ArrayHash(1, chunks=(1, 1))
     msg = r"Unable to compare .*"
     with pytest.raises(TypeError, match=msg):
         hash == object()

--- a/lib/iris/tests/unit/combine_common/test_imports.py
+++ b/lib/iris/tests/unit/combine_common/test_imports.py
@@ -1,0 +1,72 @@
+# Copyright Iris contributors
+#
+# This file is part of Iris and is released under the BSD license.
+# See LICENSE in the root of the repository for full licensing details.
+"""Test the import-freedom of :mod:`iris._combine_common`."""
+
+import ast
+from pathlib import Path
+
+from iris import _combine_common
+
+
+class RuntimeImports(ast.NodeVisitor):
+    """Collect modules imported at runtime, skipping ``TYPE_CHECKING`` blocks."""
+
+    def __init__(self):
+        self.modules: set[str] = set()
+
+    def visit_If(self, node: ast.If) -> None:
+        guard = node.test
+        type_checking = (
+            isinstance(guard, ast.Name) and guard.id == "TYPE_CHECKING"
+        ) or (isinstance(guard, ast.Attribute) and guard.attr == "TYPE_CHECKING")
+        if type_checking:
+            # Only the ``else`` branch runs at runtime.
+            for statement in node.orelse:
+                self.visit(statement)
+        else:
+            self.generic_visit(node)
+
+    def visit_Import(self, node: ast.Import) -> None:
+        self.modules.update(alias.name for alias in node.names)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        if node.level:
+            # A relative import is necessarily an Iris import.
+            self.modules.add("." * node.level + (node.module or ""))
+        elif node.module is not None:
+            self.modules.add(node.module)
+
+
+def test_no_runtime_iris_imports():
+    """The substrate sits below merge and concatenate, so imports no Iris."""
+    source = Path(_combine_common.__file__).read_text(encoding="utf-8")
+    visitor = RuntimeImports()
+    visitor.visit(ast.parse(source))
+    offenders = {
+        module
+        for module in visitor.modules
+        if module == "iris" or module.startswith(("iris.", "."))
+    }
+    assert offenders == set(), (
+        "iris._combine_common must import nothing from Iris at runtime; "
+        f"found {sorted(offenders)}. Put annotation-only imports behind "
+        "`if TYPE_CHECKING:`."
+    )
+
+
+def test_type_checking_imports_are_detected():
+    """Guard the guard: a runtime Iris import must be seen as one."""
+    source = "\n".join(
+        [
+            "from typing import TYPE_CHECKING",
+            "if TYPE_CHECKING:",
+            "    from iris.coords import DimCoord",
+            "from iris.cube import Cube",
+        ]
+    )
+    visitor = RuntimeImports()
+    visitor.visit(ast.parse(source))
+    assert "iris.cube" in visitor.modules
+    assert "iris.coords" not in visitor.modules


### PR DESCRIPTION
## 🤖 Agentic pull request

This change was written by Claude (Opus 5), driven by @bjlittle. Commits carry a
`Co-Authored-By` trailer. Please review it as you would any other contribution —
and more sceptically, if that is your inclination.

## Design Specification

See [Making Iris merge and concatenate robust, efficient and configurable](https://scitools-iris.readthedocs.io/en/greenfield/developers_guide/specs/2026-09-10-merge-concatenate-design.html) on the [greenfield](https://github.com/SciTools/iris/tree/greenfield) feature branch for full details.

For convenience, [Readthedocs ](https://app.readthedocs.org/projects/scitools-iris/?utm_source=scitools-iris&utm_content=flyout)has already been configure to automatically build the `greenfield` feature branch documentation. 

## What this does

Moves the array-hashing machinery out of `lib/iris/_concatenate.py` and into a
new private module, `lib/iris/_combine_common.py`.

This is row 1 of the roadmap in the merge and concatenate design spec (#7274),
and implements §5.1 of that spec. Nothing else in the programme lands until this
one is reviewed — it is deliberately the smallest possible first step, and it is
as much a test of whether the approach is worth continuing as it is a change.

The step-by-step plan this follows landed separately in #7275, and is at
`docs/src/developers_guide/plans/2026-09-10-hashing-substrate.md` if you want the
provenance. You should not need it to review this: the plan is a record of how
the change was arrived at, not an argument for it.

The hashing layer was added for concatenate in #5926. Merge needs exactly the
same capability, and today cannot have it without importing from
`_concatenate.py` — which `_concatenate.py` cannot offer, because it imports
`iris.cube`. The new module imports **nothing** from Iris at runtime, so either
engine can use it with no risk of a circular import. `test_imports.py` enforces
that by walking the module's AST, and a second test guards the guard so the
first cannot pass by failing to look.

## This is a relocation, not a rewrite

No behaviour changes. The moved code is identical to the original apart from
dropping the leading underscore on seven names, plus three lines noted below.
Two checks you can run yourself:

**1. The moved block is unchanged apart from the renames:**

```bash
git show upstream/greenfield:lib/iris/_concatenate.py | sed -n '305,541p' \
  | sed -e 's/\b_hash_ndarray\b/hash_ndarray/g' -e 's/\b_hash_chunk\b/hash_chunk/g' \
        -e 's/\b_hash_aggregate\b/hash_aggregate/g' -e 's/\b_hash_array\b/hash_array/g' \
        -e 's/\b_ArrayHash\b/ArrayHash/g' -e 's/\b_array_id\b/array_id/g' \
        -e 's/\b_compute_hashes\b/compute_hashes/g' > /tmp/expected.py
sed -n '/^def hash_ndarray/,$p' lib/iris/_combine_common.py > /tmp/actual.py
diff -u /tmp/expected.py /tmp/actual.py
```

Output is two hunks, three lines — the de-shadowing described below.

**2. No concatenate test was touched.** `test_hashing.py` moves to the new
package unchanged but for its import lines; no other test under
`lib/iris/tests/unit/concatenate/` is edited.

```bash
git diff upstream/greenfield --stat -- lib/iris/tests/unit/concatenate/
```

## Where to actually look

Everything above is mechanical. The only part that needed judgement is the
`array_id` rename, in two places:

- **Five call sites in `_concatenate.py`** assigned to a *local* named
  `array_id`. Once the imported function has that name, the local shadows it and
  the next line raises `UnboundLocalError`. The locals are now `points_id` and
  `bounds_id`, which is what they always meant.
- **Three bindings inside `compute_hashes` itself** had the same collision. It is
  inert — no scope in that module calls the function — but it is the same trap,
  sitting in the module that defines the name. They are now `_` and `key`.

Neither ruff nor mypy catches this class of shadowing, so it is worth a human
glance.

## An open question for the reviewer

Dropping the underscore prefix makes this a move **and** a rename, and that is a
decision I would rather you took than I did.

The case for it: these names are now a small internal API consumed by two
modules, and the underscore no longer says anything the module's own `_` prefix
does not already say.

The case against: it turns a diff you could verify by eye into one you have to
read, and it is the sole cause of all eight local renames above.

**If you would rather review a pure `git mv` with the underscores kept, say so
and I will drop the rename.** The module's *location* is what the rest of the
programme depends on; the spelling of the names is not, and I have no stake in
it.

## Testing

`pytest -n auto lib/iris/tests/unit` gives `7072 passed` against `7070` on
`greenfield` — the two additions are the new import-invariant tests. The one
pre-existing failure (`test__chunk_control.py::test_netcdf_v3`) and ten
pre-existing errors are unchanged by this branch and unrelated to it.
